### PR TITLE
Remove Repobeats analytics section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,6 @@ Contributions are welcome! Feel free to open an issue or submit a pull request. 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details. 
 Like LEGO, you're free to rebuild and reimagine as you see fit!
 
-## 📈 Repobeats Analytics
-
-![Repobeats analytics image](https://repobeats.axiom.co/api/embed/abcc9fac036c51dc10cd34ef580cca8475df93ad.svg "Repobeats analytics image")
-
 ---
 
 ## 🏢 About BondIT ApS


### PR DESCRIPTION
## 📝 Documentation Update

### **Summary**
Removed the Repobeats analytics section and its embedded image from the README.md file to clean up the documentation structure.

### **Changes Made**
- ❌ Removed the "📈 Repobeats Analytics" section (lines 122-124)
- ❌ Removed the embedded Repobeats analytics image
- ✅ Cleaned up the documentation structure

### **Why This Change**
- Simplifies the README structure
- Removes external dependency on Repobeats service
- Focuses documentation on essential project information

### **Files Changed**
-  - Removed Repobeats section

---

**Type**: Documentation  
**Priority**: Low  
**Impact**: Minimal - purely cosmetic documentation change