### PR TITLE
🔧 Fix health check endpoints to return HTTP 503 when database is offline

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -174,6 +174,26 @@ class FetchStatus(Base):
     )
 
 
+# Check database connectivity for health checks
+def check_database_health():
+    """Check if database is accessible and healthy.
+
+    Returns:
+        int: Total number of records if successful
+
+    Raises:
+        SQLAlchemyError: If database is not accessible
+    """
+    session = session_factory()
+    try:
+        # Simple query to test database connectivity
+        count = session.query(DNSLog).count()
+        logger.debug(f"✅ Database health check passed: {count:,} records")
+        return count
+    finally:
+        session.close()
+
+
 # Get total record count from database
 def get_total_record_count():
     """Get the total number of DNS log records in the database.


### PR DESCRIPTION
## 🧱 Changes

This PR fixes health check endpoints to properly return HTTP 503 Service Unavailable when the database is offline, instead of incorrectly returning HTTP 200 OK.

### Problem
All three health endpoints (`/`, `/health`, `/health/detailed`) were returning HTTP 200 OK even when the database was offline. This violates health check best practices and causes issues with:
- Load balancers (can't detect unhealthy instances)
- Container orchestration (Portainer, Docker Swarm, Kubernetes)
- Monitoring systems

### Solution
1. **Added missing imports**: `SQLAlchemyError` and `status` module
2. **Created dedicated health check function**: `check_database_health()` that raises exceptions on database connectivity issues
3. **Updated all three endpoints** to use the new function and properly return HTTP 503 when database is offline

### Testing Results
✅ **Database Online:**
- `/health` → HTTP 200 OK
- `/health/detailed` → HTTP 200 OK  
- `/` → HTTP 200 OK

✅ **Database Offline:**
- `/health` → HTTP 503 Service Unavailable
- `/health/detailed` → HTTP 503 Service Unavailable
- `/` → HTTP 503 Service Unavailable

### Files Changed
- `backend/models.py`: Added `check_database_health()` function
- `backend/main.py`: Updated health endpoints to use new function and return proper HTTP status codes

Closes #139