### PR TITLE
fix: add codecov coverage upload to main branch workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,10 +10,82 @@ permissions:
   packages: write
 
 jobs:
+  # 🧪 Run Tests and Upload Coverage (Before Build)
+  test-and-coverage-frontend:
+    name: 🧪 Frontend Tests & Coverage Upload
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: 📎 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🧪 Run tests with coverage
+        run: npm run test:coverage
+
+      - name: 📊 Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./frontend/coverage/lcov.info
+          flags: frontend,unittests
+          name: nextdns-analytics-frontend-main
+          fail_ci_if_error: false
+          verbose: true
+
+  test-and-coverage-backend:
+    name: 🧪 Backend Tests & Coverage Upload
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📎 Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: 📦 Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install -r backend/requirements-dev.txt
+
+      - name: 🧪 Run tests with coverage
+        run: |
+          cd backend
+          python -m pytest tests/ --cov=. --cov-report=xml --cov-report=term -v
+
+      - name: 📊 Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./backend/coverage.xml
+          flags: backend,unittests
+          name: nextdns-analytics-backend-main
+          fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   # 🏢 Production LEGO Assembly Line
   production-build:
     name: 🏢 Build Production LEGO Set (${{ matrix.service }})
     runs-on: ubuntu-latest
+    needs: [test-and-coverage-frontend, test-and-coverage-backend]
 
     strategy:
       matrix:


### PR DESCRIPTION
- Added test-and-coverage-frontend job to run tests and upload coverage
- Added test-and-coverage-backend job to run tests and upload coverage
- production-build now depends on both coverage jobs
- This ensures codecov receives coverage data from main branch
- Fixes codecov reporting issue where main branch had no coverage data