### PR TITLE
feat: Add profile-based filtering for Query Breakdown chart (#220)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -112,7 +112,7 @@
     {
       "label": "Backend: Setup Virtual Environment",
       "type": "shell",
-      "command": "cd backend && python3 -m venv venv && source venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt && pip install -r requirements-dev.txt && echo '✅ Virtual environment created!'",
+      "command": "cd backend && python3 -m venv venv && . venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt && pip install -r requirements-dev.txt && echo '✅ Virtual environment created!'",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -122,7 +122,7 @@
     {
       "label": "Backend: Run Tests",
       "type": "shell",
-      "command": "cd backend && source venv/bin/activate && pytest tests/ -v",
+      "command": "cd backend && . venv/bin/activate && pytest tests/ -v",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -136,7 +136,7 @@
     {
       "label": "Backend: Run Tests with Coverage",
       "type": "shell",
-      "command": "cd backend && source venv/bin/activate && pytest tests/ --cov=. --cov-report=html --cov-report=term",
+      "command": "cd backend && . venv/bin/activate && pytest tests/ --cov=. --cov-report=html --cov-report=term",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -150,7 +150,7 @@
     {
       "label": "🧪 Backend: Run Unit Tests Only",
       "type": "shell",
-      "command": "cd backend && source venv/bin/activate && pytest -m unit -v",
+      "command": "cd backend && . venv/bin/activate && pytest -m unit -v",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -164,7 +164,7 @@
     {
       "label": "🧪 Backend: Run Integration Tests Only",
       "type": "shell",
-      "command": "cd backend && source venv/bin/activate && pytest -m integration -v",
+      "command": "cd backend && . venv/bin/activate && pytest -m integration -v",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -178,7 +178,7 @@
     {
       "label": "Backend: Format (Black)",
       "type": "shell",
-      "command": "cd backend && source venv/bin/activate && black . --line-length=88 --exclude='(alembic|venv)'",
+      "command": "cd backend && . venv/bin/activate && black . --line-length=88 --exclude='(alembic|venv)'",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -188,7 +188,7 @@
     {
       "label": "Backend: Check Formatting",
       "type": "shell",
-      "command": "cd backend && source venv/bin/activate && black . --check --line-length=88 --exclude='(alembic|venv)'",
+      "command": "cd backend && . venv/bin/activate && black . --check --line-length=88 --exclude='(alembic|venv)'",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -198,7 +198,7 @@
     {
       "label": "Backend: Lint (Pylint)",
       "type": "shell",
-      "command": "cd backend && source venv/bin/activate && pylint . --rcfile=../.pylintrc",
+      "command": "cd backend && . venv/bin/activate && pylint . --rcfile=../.pylintrc",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -212,7 +212,7 @@
     {
       "label": "Backend: Security Scan (Bandit)",
       "type": "shell",
-      "command": "cd backend && source venv/bin/activate && bandit -r . -x tests/",
+      "command": "cd backend && . venv/bin/activate && bandit -r . -x tests/",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -304,7 +304,7 @@
     {
       "label": "Security: Full Scan",
       "type": "shell",
-      "command": "cd frontend && npm audit --audit-level=high && cd ../backend && source venv/bin/activate && bandit -r . -x tests/",
+      "command": "cd frontend && npm audit --audit-level=high && cd ../backend && . venv/bin/activate && bandit -r . -x tests/",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",

--- a/frontend/src/components/ProfileFilter.tsx
+++ b/frontend/src/components/ProfileFilter.tsx
@@ -1,0 +1,245 @@
+import { memo, useState, useMemo } from 'react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import {
+  Layers,
+  Search,
+  ChevronDown,
+  ChevronUp,
+  X,
+  CheckSquare,
+  Square,
+} from 'lucide-react'
+
+interface ProfileFilterProps {
+  availableProfiles: string[]
+  selectedProfiles: string[]
+  onProfileSelectionChange: (profiles: string[]) => void
+  profileColors: Record<string, string>
+  profileNames?: Record<string, string> // Optional profile ID to name mapping
+}
+
+export const ProfileFilter = memo<ProfileFilterProps>(
+  ({
+    availableProfiles,
+    selectedProfiles,
+    onProfileSelectionChange,
+    profileColors,
+    profileNames = {},
+  }) => {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const [searchQuery, setSearchQuery] = useState('')
+
+    // Filter profiles based on search query
+    const filteredProfiles = useMemo(() => {
+      if (!searchQuery.trim()) return availableProfiles
+      return availableProfiles.filter(profileId => {
+        const name = profileNames[profileId] || profileId
+        return name.toLowerCase().includes(searchQuery.toLowerCase())
+      })
+    }, [availableProfiles, searchQuery, profileNames])
+
+    const handleProfileToggle = (profileId: string) => {
+      const isSelected = selectedProfiles.includes(profileId)
+      if (isSelected) {
+        onProfileSelectionChange(selectedProfiles.filter(p => p !== profileId))
+      } else {
+        onProfileSelectionChange([...selectedProfiles, profileId])
+      }
+    }
+
+    const handleSelectAll = () => {
+      onProfileSelectionChange(filteredProfiles)
+    }
+
+    const handleSelectNone = () => {
+      onProfileSelectionChange([])
+    }
+
+    const handleRemoveProfile = (profileId: string) => {
+      onProfileSelectionChange(selectedProfiles.filter(p => p !== profileId))
+    }
+
+    const getProfileDisplayName = (profileId: string): string => {
+      return profileNames[profileId] || profileId
+    }
+
+    // Don't show the filter if no profiles available
+    if (!availableProfiles || availableProfiles.length === 0) {
+      return (
+        <Card className="opacity-50">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Layers className="h-5 w-5" />
+              Profile Filter
+            </CardTitle>
+            <CardDescription>
+              No profiles available. Start fetching data.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )
+    }
+
+    return (
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Layers className="h-5 w-5" />
+                Profile Filter
+                {selectedProfiles.length > 0 && (
+                  <Badge variant="secondary" className="ml-2">
+                    {selectedProfiles.length}
+                  </Badge>
+                )}
+              </CardTitle>
+              <CardDescription>
+                Select profiles to display in the chart
+              </CardDescription>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsExpanded(!isExpanded)}
+              className="flex items-center gap-1"
+            >
+              {isExpanded ? (
+                <>
+                  <ChevronUp className="h-4 w-4" />
+                  Collapse
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-4 w-4" />
+                  Expand
+                </>
+              )}
+            </Button>
+          </div>
+        </CardHeader>
+
+        {/* Selected profiles display (always visible) */}
+        {selectedProfiles.length > 0 && (
+          <CardContent className="pt-0">
+            <div className="flex flex-wrap gap-2">
+              {selectedProfiles.map(profileId => (
+                <Badge
+                  key={profileId}
+                  variant="default"
+                  className="flex items-center gap-2"
+                  style={{
+                    backgroundColor: `${profileColors[profileId]}20`,
+                    borderColor: profileColors[profileId],
+                    borderWidth: '2px',
+                    color: 'inherit',
+                  }}
+                >
+                  <div
+                    className="h-3 w-3 rounded-full"
+                    style={{ backgroundColor: profileColors[profileId] }}
+                  />
+                  {getProfileDisplayName(profileId)}
+                  <button
+                    onClick={() => handleRemoveProfile(profileId)}
+                    className="ml-1 hover:text-destructive"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        )}
+
+        {/* Expanded profile selection */}
+        {isExpanded && (
+          <CardContent className={selectedProfiles.length > 0 ? 'pt-0' : ''}>
+            <div className="space-y-4">
+              {/* Search input */}
+              <div className="relative">
+                <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search profiles..."
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
+                  className="pl-8"
+                />
+              </div>
+
+              {/* Select all/none buttons */}
+              {filteredProfiles.length > 0 && (
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSelectAll}
+                    disabled={filteredProfiles.every(profile =>
+                      selectedProfiles.includes(profile)
+                    )}
+                  >
+                    Select All
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSelectNone}
+                    disabled={selectedProfiles.length === 0}
+                  >
+                    Clear All
+                  </Button>
+                </div>
+              )}
+
+              {/* Profile list */}
+              <div className="max-h-60 overflow-y-auto space-y-1">
+                {filteredProfiles.length === 0 ? (
+                  <div className="text-sm text-muted-foreground text-center py-4">
+                    {searchQuery
+                      ? 'No profiles match your search.'
+                      : 'No profiles found.'}
+                  </div>
+                ) : (
+                  filteredProfiles.map(profileId => {
+                    const isSelected = selectedProfiles.includes(profileId)
+                    return (
+                      <div
+                        key={profileId}
+                        className="flex items-center space-x-2 p-2 hover:bg-muted rounded cursor-pointer"
+                        onClick={() => handleProfileToggle(profileId)}
+                      >
+                        <div
+                          className="h-3 w-3 rounded-full"
+                          style={{ backgroundColor: profileColors[profileId] }}
+                        />
+                        {isSelected ? (
+                          <CheckSquare className="h-4 w-4 text-primary" />
+                        ) : (
+                          <Square className="h-4 w-4 text-muted-foreground" />
+                        )}
+                        <span className="text-sm font-medium">
+                          {getProfileDisplayName(profileId)}
+                        </span>
+                      </div>
+                    )
+                  })
+                )}
+              </div>
+            </div>
+          </CardContent>
+        )}
+      </Card>
+    )
+  }
+)
+
+ProfileFilter.displayName = 'ProfileFilter'

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -153,6 +153,7 @@ export default function Stats() {
       const params = new URLSearchParams()
       if (selectedProfile !== 'all') params.set('profile', selectedProfile)
       params.set('time_range', timeRange)
+      params.set('group_by', 'profile') // Use profile grouping for chart
 
       console.log('Fetching stats data with params:', params.toString())
 


### PR DESCRIPTION
## Summary
Implements profile-based grouping for the "Query Breakdown by Time" chart, allowing users to filter and visualize queries by NextDNS profile instead of blocked/allowed status.

Closes #220

## Backend Changes
- ✅ Add `group_by` parameter to `get_stats_timeseries()` with `'status'` (default) and `'profile'` modes
- ✅ Update `TimeSeriesDataPoint` model to include optional `profiles` field
- ✅ Update `TimeSeriesResponse` model to include `available_profiles` field
- ✅ Maintain backward compatibility with existing `'status'` grouping mode
- ✅ Add pylint suppressions for SQLAlchemy `func.count` false positives
- ✅ Fix no-else-return pylint warnings

## Frontend Changes
- ✅ Create new `ProfileFilter` component for profile selection UI
- ✅ Update `ChartJsOverview` to support profile-based datasets
- ✅ Fetch and display profile names instead of IDs from `/api/profiles/info`
- ✅ Implement dynamic color assignment (LEGO colors + golden angle for 8+)
- ✅ Update `Stats` page to request `group_by=profile` parameter
- ✅ Add profile name resolution with fallback to profile ID

## Developer Experience
- ✅ Fix VSCode tasks to use sh-compatible syntax (`.` instead of `source`)
- ✅ Update CLAUDE.md with pre-commit quality check commands
- ✅ All tests passing (89 passed, 4 skipped)
- ✅ Pylint score: 9.57/10

## Test Plan
- [x] Backend tests pass (89 passed, 4 skipped - bcrypt Python 3.14 compatibility)
- [x] Pylint passes with 9.57/10 score
- [x] Black formatting passes
- [ ] Manual testing: Verify profile filter UI works correctly
- [ ] Manual testing: Verify chart displays profile names (not IDs)
- [ ] Manual testing: Verify color assignment works for 1-7 profiles
- [ ] Manual testing: Test with 8+ profiles (golden angle colors)
- [ ] Manual testing: Test profile selection/deselection
- [ ] Manual testing: Test with different time ranges (1h, 24h, 7d, 30d)

## Screenshots
<img width="1378" height="539" alt="image" src="https://github.com/user-attachments/assets/ba018efe-af61-43a5-a52e-a1bfdd9e5fac" />
