### PR TITLE
🐛 Fix push-version-tag job being skipped

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -258,7 +258,10 @@ jobs:
     name: 🏷️ Push Version Tag
     runs-on: ubuntu-latest
     needs: [calculate-version, production-build]
-    if: success()
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     steps:
       - name: 📎 Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem
The push-version-tag job was always being skipped, meaning no git tags were ever pushed. This caused every build to calculate 26.2.1 since no previous tags existed.

## Root Cause
The job used if: success() which requires ALL upstream jobs to have the success conclusion. However, production-build uses if: always() with a matrix strategy so GitHub marks such jobs with a non-standard conclusion that success() does not recognize.

## Fix
Changed the condition to always() with failure/cancelled guards, matching the same pattern already used by the production-build job.

## Expected Result
After this fix, successful builds will push git tags (e.g. 26.2.1, 26.2.2) and the patch number will correctly increment.