### PR TITLE
✨ Add worker pod support for K8s multi-pod deployments

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -66,13 +66,21 @@ app_start_time = datetime.now(timezone.utc)
 # Version from Docker build arg / environment variable
 APP_VERSION = os.getenv("APP_VERSION", "dev")
 
-try:
-    from scheduler import scheduler  # pylint: disable=unused-import,duplicate-code
+# Scheduler initialization (can be disabled for K8s multi-pod deployments)
+# Default: enabled (backward compatible with Docker Compose and single-pod deployments)
+DISABLE_SCHEDULER = os.getenv("DISABLE_SCHEDULER", "false").lower() == "true"
 
-    logger.info("🔄 NextDNS log scheduler started successfully")
-except ImportError as e:
-    logger.warning(f"⚠️  Could not start scheduler: {e}")
-    logger.info("🧱 App will work but won't automatically fetch NextDNS logs")
+if not DISABLE_SCHEDULER:
+    try:
+        from scheduler import scheduler  # pylint: disable=unused-import,duplicate-code
+
+        logger.info("🔄 NextDNS log scheduler started successfully")
+    except ImportError as e:
+        logger.warning(f"⚠️  Could not start scheduler: {e}")
+        logger.info("🧱 App will work but won't automatically fetch NextDNS logs")
+else:
+    logger.info("🔇 Scheduler disabled (DISABLE_SCHEDULER=true)")
+    logger.info("💡 Use separate worker pod for DNS log fetching in K8s multi-pod setup")
 
 
 @asynccontextmanager

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+NextDNS Analytics Worker Process
+
+Standalone worker that runs the DNS log fetch scheduler.
+Used in Kubernetes multi-pod deployments to avoid scheduler conflicts.
+
+Usage:
+    python worker.py
+
+Environment Variables:
+    - All standard NextDNS configuration (API_KEY, PROFILE_IDS, etc.)
+    - FETCH_INTERVAL: Scheduler interval in minutes (default: 60)
+    - LOG_LEVEL: Logging level (DEBUG, INFO, WARNING, ERROR)
+
+Deployment Modes:
+    - Docker Compose: Not needed (scheduler runs in backend container)
+    - K8s Single-Pod: Not needed (scheduler runs in backend pod)
+    - K8s Multi-Pod: Use this worker (deploy as separate single-replica pod)
+"""
+
+import os
+import signal
+import sys
+import threading
+
+# Set up logging first
+from logging_config import setup_logging, get_logger
+
+setup_logging()
+logger = get_logger(__name__)
+
+# Graceful shutdown via threading.Event (avoids sys.exit in signal handler)
+shutdown_event = threading.Event()
+
+
+def signal_handler(signum, _frame):
+    """Handle shutdown signals gracefully."""
+    signal_name = signal.Signals(signum).name
+    logger.info(f"🛑 Received {signal_name}, shutting down worker gracefully...")
+    shutdown_event.set()
+
+
+def main():
+    """Run the NextDNS log fetch scheduler as a standalone worker process."""
+    logger.info("🚀 Starting NextDNS Analytics Worker")
+    logger.info("📋 Worker runs DNS log fetch scheduler only (no HTTP server)")
+
+    # Register signal handlers for graceful shutdown
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    # Initialize database connection
+    logger.info("🗄️  Initializing database connection...")
+    try:
+        from models import init_db
+
+        init_db()
+        logger.info("✅ Database connection initialized")
+    except Exception as e:
+        logger.error(f"❌ Failed to initialize database: {e}")
+        sys.exit(1)
+
+    # Import and start the scheduler
+    logger.info("🔄 Starting NextDNS log fetch scheduler...")
+    try:
+        from scheduler import scheduler  # pylint: disable=unused-import
+
+        logger.info("✅ Scheduler started successfully")
+
+        # Log scheduler configuration
+        fetch_interval = int(os.getenv("FETCH_INTERVAL", "60"))
+        api_key_configured = bool(os.getenv("API_KEY"))
+        profile_ids = os.getenv("PROFILE_IDS", "")
+        profile_count = len(profile_ids.split(",")) if profile_ids else 0
+
+        logger.info(f"⏰ Fetch interval: {fetch_interval} minutes")
+        logger.info(f"🔑 API Key configured: {api_key_configured}")
+        logger.info(f"📊 Monitoring {profile_count} profile(s)")
+
+        if not api_key_configured or profile_count == 0:
+            logger.warning(
+                "⚠️  Worker started but NextDNS API credentials not configured"
+            )
+            logger.warning(
+                "⚠️  Scheduler will not fetch logs until credentials are set"
+            )
+
+    except ImportError as e:
+        logger.error(f"❌ Failed to import scheduler: {e}")
+        logger.error(
+            "❌ Ensure scheduler.py is present and all dependencies are installed"
+        )
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"❌ Failed to start scheduler: {e}")
+        sys.exit(1)
+
+    # Keep the worker running until shutdown signal
+    logger.info("✅ Worker is running and healthy")
+    logger.info("🔄 Scheduler will fetch logs according to configured interval")
+
+    while not shutdown_event.is_set():
+        shutdown_event.wait(60)  # Wake every 60s or on signal
+        if not shutdown_event.is_set():
+            # Periodic health check log (only in DEBUG mode)
+            if os.getenv("LOG_LEVEL", "INFO").upper() == "DEBUG":
+                logger.debug("💓 Worker heartbeat: scheduler running")
+
+    logger.info("🛑 Worker stopped gracefully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview

Adds **backward-compatible** worker pod separation for Kubernetes multi-pod deployments, solving scheduler conflicts when running multiple backend replicas.

## Problem

When running multiple backend pods in Kubernetes, all pods run the APScheduler → duplicate DNS log fetching and wasted API calls.

## Changes

### `backend/main.py` — DISABLE_SCHEDULER env var
- New `DISABLE_SCHEDULER` env var (default: `false`, fully backward compatible)
- When `true`, scheduler import is skipped — backend becomes a pure API server
- Helm chart auto-sets this when `worker.enabled: true`

### `backend/worker.py` — Standalone scheduler process (new file)
- Runs APScheduler without HTTP server
- Graceful shutdown via `threading.Event` (no `sys.exit` in signal handlers)
- Calls `init_db()` on startup to ensure DB tables exist
- Periodic heartbeat logging in DEBUG mode

## Deployment Modes

| Mode | Config | Scheduler Location |
|------|--------|-------------------|
| Docker Compose | Default | Backend container |
| K8s Single-Pod | Default | Backend pod |
| K8s Multi-Pod | `DISABLE_SCHEDULER=true` | Worker pod |

## Testing
- ✅ All 111 backend tests passing
- ✅ Syntax validation completed
- ✅ No breaking changes to APIs

## Related
- **Companion PR**: `consultant-portal-infra` (Helm chart changes — HPA + worker enablement)
- Replaces closed PR #307