### PR TITLE
feat: add NextDNS configuration management API (issue #117)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -178,7 +178,7 @@
     {
       "label": "Backend: Format (Black)",
       "type": "shell",
-      "command": "cd backend && . venv/bin/activate && black . --line-length=88 --exclude='(alembic|venv)'",
+      "command": "cd backend && . venv/bin/activate && black . --line-length=85 --exclude='(alembic|venv)'",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",
@@ -188,7 +188,7 @@
     {
       "label": "Backend: Check Formatting",
       "type": "shell",
-      "command": "cd backend && . venv/bin/activate && black . --check --line-length=88 --exclude='(alembic|venv)'",
+      "command": "cd backend && . venv/bin/activate && black . --check --line-length=85 --exclude='(alembic|venv)'",
       "problemMatcher": [],
       "presentation": {
         "reveal": "always",

--- a/backend/alembic/versions/2026_02_18_a1b2c3d4e5f6_add_system_settings_and_nextdns_profiles.py
+++ b/backend/alembic/versions/2026_02_18_a1b2c3d4e5f6_add_system_settings_and_nextdns_profiles.py
@@ -1,0 +1,84 @@
+"""add_system_settings_and_nextdns_profiles
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5af432e004a8
+Create Date: 2026-02-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "5af432e004a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create system_settings and nextdns_profiles tables.
+
+    system_settings — generic key/value store for application configuration.
+      First key: nextdns_api_key (migrates from API_KEY env var on first boot).
+      Additional keys will be added in issue #115.
+
+    nextdns_profiles — managed list of NextDNS profiles the scheduler fetches.
+      Replaces the PROFILE_IDS env var (seeded from it on first boot).
+    """
+    op.create_table(
+        "system_settings",
+        sa.Column("key", sa.String(100), primary_key=True),
+        sa.Column("value", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_table(
+        "nextdns_profiles",
+        sa.Column("profile_id", sa.String(50), primary_key=True),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_index(
+        "idx_nextdns_profiles_enabled",
+        "nextdns_profiles",
+        ["enabled"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop system_settings and nextdns_profiles tables."""
+    op.drop_index("idx_nextdns_profiles_enabled", table_name="nextdns_profiles")
+    op.drop_table("nextdns_profiles")
+    op.drop_table("system_settings")

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -92,7 +92,9 @@ def get_password_hash(password: str) -> str:
 
 
 # JWT token functions
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+def create_access_token(
+    data: dict, expires_delta: Optional[timedelta] = None
+) -> str:
     """Create a JWT access token."""
     to_encode = data.copy()
     if expires_delta:

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,7 +80,9 @@ DISABLE_SCHEDULER = os.getenv("DISABLE_SCHEDULER", "false").lower() == "true"
 
 if not DISABLE_SCHEDULER:
     try:
-        from scheduler import scheduler  # pylint: disable=unused-import,duplicate-code
+        from scheduler import (
+            scheduler,
+        )  # pylint: disable=unused-import,duplicate-code
 
         logger.info("🔄 NextDNS log scheduler started successfully")
     except ImportError as e:
@@ -191,7 +193,9 @@ def verify_api_key(credentials: HTTPAuthorizationCredentials = Depends(security)
 # Flexible authentication supporting both Bearer and X-API-Key
 def verify_api_key_flexible(
     x_api_key: str = Header(None),
-    credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
+    credentials: HTTPAuthorizationCredentials = Depends(
+        HTTPBearer(auto_error=False)
+    ),
 ):
     """Authenticate user with API key via Bearer token or X-API-Key header."""
     api_key = None
@@ -591,7 +595,9 @@ async def detailed_health_check():
         total_records = get_total_record_count()
 
         # Calculate uptime
-        uptime_seconds = (datetime.now(timezone.utc) - app_start_time).total_seconds()
+        uptime_seconds = (
+            datetime.now(timezone.utc) - app_start_time
+        ).total_seconds()
 
         # Get environment configuration
         fetch_interval = int(os.getenv("FETCH_INTERVAL", "60"))
@@ -599,7 +605,9 @@ async def detailed_health_check():
 
         # Create metrics components
         backend_resources = _create_backend_resources(uptime_seconds)
-        backend_health = BackendHealth(status="healthy", uptime_seconds=uptime_seconds)
+        backend_health = BackendHealth(
+            status="healthy", uptime_seconds=uptime_seconds
+        )
         backend_metrics = BackendMetrics(
             resources=backend_resources, health=backend_health
         )
@@ -795,7 +803,10 @@ async def get_dns_logs(  # pylint: disable=too-many-positional-arguments
         default="all", description="Time range: 30m, 1h, 6h, 24h, 7d, 30d, 3m, all"
     ),
     limit: int = Query(
-        default=100, ge=1, le=10000, description="Maximum number of records to return"
+        default=100,
+        ge=1,
+        le=10000,
+        description="Maximum number of records to return",
     ),
     offset: int = Query(default=0, ge=0, description="Number of records to skip"),
     current_user: str = Depends(get_current_user),
@@ -862,11 +873,15 @@ async def get_profile_information(current_user: str = Depends(get_current_user))
     profile_info = get_multiple_profiles_info(configured_profiles)
     logger.info(f"🧱 Returning information for {len(profile_info)} profiles")
 
-    return ProfileInfoResponse(profiles=profile_info, total_profiles=len(profile_info))
+    return ProfileInfoResponse(
+        profiles=profile_info, total_profiles=len(profile_info)
+    )
 
 
 @app.get(
-    "/profiles/{profile_id}/info", response_model=NextDNSProfileInfo, tags=["Profiles"]
+    "/profiles/{profile_id}/info",
+    response_model=NextDNSProfileInfo,
+    tags=["Profiles"],
 )
 async def get_single_profile_info(
     profile_id: str, current_user: str = Depends(get_current_user)
@@ -885,7 +900,9 @@ async def get_single_profile_info(
     return NextDNSProfileInfo(**profile_info)
 
 
-@app.get("/stats/overview", response_model=StatsOverviewResponse, tags=["Statistics"])
+@app.get(
+    "/stats/overview", response_model=StatsOverviewResponse, tags=["Statistics"]
+)
 async def get_stats_overview(
     profile: Optional[str] = Query(
         default=None, description="Filter by specific profile ID"

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,14 @@ from models import (
     get_total_record_count,
     get_logs_stats,
     check_database_health,
+    get_nextdns_api_key,
+    set_nextdns_api_key,
+    get_all_profiles,
+    get_profile,
+    add_profile,
+    update_profile_enabled,
+    delete_profile,
+    migrate_config_from_env,
 )
 from models import get_available_profiles as get_profiles_from_db
 from models import (
@@ -92,6 +100,8 @@ async def lifespan(app: FastAPI):
     logger.info("🚀 Starting NextDNS Optimized Analytics FastAPI Backend")
     init_db()  # Ensure the database is initialized
     init_auth()  # Initialize authentication system
+    if migrate_config_from_env():
+        logger.info("🔑 NextDNS config seeded from environment variables")
     logger.info("✅ FastAPI application startup completed")
     yield
     # Shutdown (if needed in the future)
@@ -1135,6 +1145,246 @@ async def get_device_stats(
     devices = [DeviceUsageItem(**device) for device in device_results]
 
     return DeviceStatsResponse(devices=devices)
+
+
+# ---------------------------------------------------------------------------
+# Settings — NextDNS configuration (API key + profile management)
+# ---------------------------------------------------------------------------
+
+
+class ApiKeyResponse(BaseModel):
+    """Masked API key response."""
+
+    configured: bool
+    masked_key: Optional[str] = None  # e.g. "••••••••ab12"
+
+
+class ApiKeyUpdateRequest(BaseModel):
+    """Request body for updating the NextDNS API key."""
+
+    api_key: str
+
+
+class SettingsProfileItem(BaseModel):
+    """A single NextDNS profile entry from the settings table."""
+
+    profile_id: str
+    enabled: bool
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class SettingsProfileListResponse(BaseModel):
+    """List of configured NextDNS profiles from the settings table."""
+
+    profiles: List[SettingsProfileItem]
+    total: int
+
+
+class AddProfileRequest(BaseModel):
+    """Request body for adding a new profile."""
+
+    profile_id: str
+
+
+class UpdateProfileRequest(BaseModel):
+    """Request body for enabling/disabling a profile."""
+
+    enabled: bool
+
+
+class DeleteProfileResponse(BaseModel):
+    """Response after deleting a profile."""
+
+    deleted: bool
+    profile_id: str
+    dns_logs_deleted: int
+    fetch_status_deleted: int
+
+
+def _mask_api_key(key: str) -> str:
+    """Return a masked version of *key* showing only the last 4 characters."""
+    if len(key) <= 4:
+        return "••••"
+    return "•" * (len(key) - 4) + key[-4:]
+
+
+def _validate_nextdns_api_key(api_key: str) -> bool:
+    """Check the key against the NextDNS API by listing profiles.
+
+    Returns True if the key is accepted (HTTP 200), False otherwise.
+    """
+    try:
+        response = __import__("requests").get(
+            "https://api.nextdns.io/profiles",
+            headers={"X-Api-Key": api_key},
+            timeout=10,
+        )
+        return response.status_code == 200
+    except Exception:  # pylint: disable=broad-exception-caught
+        return False
+
+
+@app.get(
+    "/settings/nextdns/api-key",
+    response_model=ApiKeyResponse,
+    tags=["Settings"],
+)
+async def get_api_key_setting(
+    current_user: str = Depends(get_current_user),
+):
+    """Return whether a NextDNS API key is configured and its masked value."""
+    key = get_nextdns_api_key()
+    if not key:
+        return ApiKeyResponse(configured=False)
+    return ApiKeyResponse(configured=True, masked_key=_mask_api_key(key))
+
+
+@app.put(
+    "/settings/nextdns/api-key",
+    response_model=ApiKeyResponse,
+    tags=["Settings"],
+)
+async def update_api_key_setting(
+    body: ApiKeyUpdateRequest,
+    current_user: str = Depends(get_current_user),
+):
+    """Validate the provided key against the NextDNS API and persist it."""
+    api_key = body.api_key.strip()
+    if not api_key:
+        raise HTTPException(status_code=400, detail="api_key must not be empty")
+
+    if not _validate_nextdns_api_key(api_key):
+        raise HTTPException(
+            status_code=422,
+            detail="API key rejected by NextDNS — check that it is valid",
+        )
+
+    if not set_nextdns_api_key(api_key):
+        raise HTTPException(status_code=500, detail="Failed to save API key")
+
+    logger.info("🔑 NextDNS API key updated via settings endpoint")
+    return ApiKeyResponse(configured=True, masked_key=_mask_api_key(api_key))
+
+
+@app.get(
+    "/settings/nextdns/profiles",
+    response_model=SettingsProfileListResponse,
+    tags=["Settings"],
+)
+async def list_settings_profiles(
+    current_user: str = Depends(get_current_user),
+):
+    """Return all configured NextDNS profiles (enabled and disabled)."""
+    rows = get_all_profiles()
+    items = [
+        SettingsProfileItem(
+            profile_id=r.profile_id,
+            enabled=r.enabled,
+            created_at=r.created_at.isoformat() if r.created_at else None,
+            updated_at=r.updated_at.isoformat() if r.updated_at else None,
+        )
+        for r in rows
+    ]
+    return SettingsProfileListResponse(profiles=items, total=len(items))
+
+
+@app.post(
+    "/settings/nextdns/profiles",
+    response_model=SettingsProfileItem,
+    status_code=status.HTTP_201_CREATED,
+    tags=["Settings"],
+)
+async def add_settings_profile(
+    body: AddProfileRequest,
+    current_user: str = Depends(get_current_user),
+):
+    """Add a new NextDNS profile after validating it exists on NextDNS."""
+    profile_id = body.profile_id.strip()
+    if not profile_id:
+        raise HTTPException(status_code=400, detail="profile_id must not be empty")
+
+    # Verify the profile exists on NextDNS
+    api_key = get_nextdns_api_key()
+    if not api_key:
+        raise HTTPException(
+            status_code=422,
+            detail="No NextDNS API key configured — set it via PUT /settings/nextdns/api-key first",
+        )
+
+    profile_info = get_profile_info(profile_id)
+    if not profile_info or profile_info.get("error"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Profile '{profile_id}' not found or not accessible with the current API key",
+        )
+
+    if not add_profile(profile_id):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Profile '{profile_id}' already exists",
+        )
+
+    row = get_profile(profile_id)
+    return SettingsProfileItem(
+        profile_id=row.profile_id,
+        enabled=row.enabled,
+        created_at=row.created_at.isoformat() if row.created_at else None,
+        updated_at=row.updated_at.isoformat() if row.updated_at else None,
+    )
+
+
+@app.put(
+    "/settings/nextdns/profiles/{profile_id}",
+    response_model=SettingsProfileItem,
+    tags=["Settings"],
+)
+async def update_settings_profile(
+    profile_id: str,
+    body: UpdateProfileRequest,
+    current_user: str = Depends(get_current_user),
+):
+    """Enable or disable a NextDNS profile."""
+    if not update_profile_enabled(profile_id, body.enabled):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Profile '{profile_id}' not found",
+        )
+    row = get_profile(profile_id)
+    return SettingsProfileItem(
+        profile_id=row.profile_id,
+        enabled=row.enabled,
+        created_at=row.created_at.isoformat() if row.created_at else None,
+        updated_at=row.updated_at.isoformat() if row.updated_at else None,
+    )
+
+
+@app.delete(
+    "/settings/nextdns/profiles/{profile_id}",
+    response_model=DeleteProfileResponse,
+    tags=["Settings"],
+)
+async def delete_settings_profile(
+    profile_id: str,
+    purge_data: bool = Query(
+        default=True,
+        description="Also delete all DNS logs and fetch status for this profile",
+    ),
+    current_user: str = Depends(get_current_user),
+):
+    """Delete a profile and optionally purge all its DNS log data."""
+    result = delete_profile(profile_id, delete_data=purge_data)
+    if not result["deleted"]:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Profile '{profile_id}' not found",
+        )
+    return DeleteProfileResponse(
+        deleted=True,
+        profile_id=profile_id,
+        dns_logs_deleted=result["dns_logs_deleted"],
+        fetch_status_deleted=result["fetch_status_deleted"],
+    )
 
 
 if __name__ == "__main__":

--- a/backend/manage_db.py
+++ b/backend/manage_db.py
@@ -53,7 +53,10 @@ def check_environment():
     # Database connection variables (required for migrations)
     db_vars = ["POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB", "POSTGRES_HOST"]
     # NextDNS API variables (optional for migrations, but needed for the app to work)
-    api_vars = ["API_KEY", "PROFILE_ID", "LOCAL_API_KEY"]
+    # Note: API_KEY and PROFILE_IDS are seeded into the database on first boot.
+    # They can also be managed dynamically via PUT /settings/nextdns/api-key
+    # and POST /settings/nextdns/profiles after startup.
+    api_vars = ["LOCAL_API_KEY"]
 
     missing_db_vars = []
     missing_api_vars = []

--- a/backend/manage_db.py
+++ b/backend/manage_db.py
@@ -35,7 +35,11 @@ def run_alembic_command(command_args):
         cmd = ["alembic"] + command_args
         logger.info(f"🧱 Running: {' '.join(cmd)}")
         result = subprocess.run(
-            cmd, cwd=Path(__file__).parent, check=True, capture_output=True, text=True
+            cmd,
+            cwd=Path(__file__).parent,
+            check=True,
+            capture_output=True,
+            text=True,
         )
         logger.info(result.stdout)
         if result.stderr:

--- a/backend/models.py
+++ b/backend/models.py
@@ -166,10 +166,14 @@ class ForceText(TypeDecorator):  # pylint: disable=too-many-ancestors
             return str(value)
         return value
 
-    def process_result_value(self, value, dialect):  # pylint: disable=unused-argument
+    def process_result_value(
+        self, value, dialect
+    ):  # pylint: disable=unused-argument
         return value
 
-    def process_literal_param(self, value, dialect):  # pylint: disable=unused-argument
+    def process_literal_param(
+        self, value, dialect
+    ):  # pylint: disable=unused-argument
         """Process literal parameter for SQL compilation."""
         return str(value) if value is not None else value
 
@@ -220,7 +224,9 @@ class DNSLog(Base):
     tld = Column(
         String(255), nullable=True
     )  # Computed TLD for fast aggregation (Phase 3)
-    data = Column(ForceText, nullable=False)  # Store original raw data as JSON string
+    data = Column(
+        ForceText, nullable=False
+    )  # Store original raw data as JSON string
     created_at = Column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
@@ -383,7 +389,9 @@ def add_log(log):
         existing_log = (
             session.query(DNSLog)
             .filter_by(
-                timestamp=log_timestamp, domain=log.get("domain"), client_ip=client_ip
+                timestamp=log_timestamp,
+                domain=log.get("domain"),
+                client_ip=client_ip,
             )
             .first()
         )
@@ -1050,7 +1058,9 @@ def get_stats_timeseries(
         elif time_range == "7d":
             # For daily data, align to start of today and work backwards
             today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-            start_time = today_start - timedelta(days=6)  # 6 days back + today = 7 days
+            start_time = today_start - timedelta(
+                days=6
+            )  # 6 days back + today = 7 days
             interval_hours = 24
             num_intervals = 7  # 7 x 1day = 7 days
             granularity = "day"
@@ -1139,7 +1149,9 @@ def get_stats_timeseries(
                 elif time_range == "1h":
                     # Round to nearest 5 minutes
                     display_time = interval_start.replace(
-                        minute=(interval_start.minute // 5) * 5, second=0, microsecond=0
+                        minute=(interval_start.minute // 5) * 5,
+                        second=0,
+                        microsecond=0,
                     )
                 elif time_range == "6h":
                     # Round to nearest 15 minutes
@@ -1234,7 +1246,9 @@ def get_stats_timeseries(
         # Return format depends on grouping mode
         if group_by == "profile":
             # Get list of all available profiles from the query
-            all_profiles = base_query.with_entities(DNSLog.profile_id).distinct().all()
+            all_profiles = (
+                base_query.with_entities(DNSLog.profile_id).distinct().all()
+            )
             available_profiles = [p[0] for p in all_profiles if p[0]]
 
             return {
@@ -1640,10 +1654,14 @@ def get_stats_devices(  # pylint: disable=too-many-locals,too-many-branches
         device_results = []
         for device_name, stats in device_stats.items():
             blocked_percentage = (
-                (stats["blocked"] / stats["total"] * 100) if stats["total"] > 0 else 0
+                (stats["blocked"] / stats["total"] * 100)
+                if stats["total"] > 0
+                else 0
             )
             allowed_percentage = (
-                (stats["allowed"] / stats["total"] * 100) if stats["total"] > 0 else 0
+                (stats["allowed"] / stats["total"] * 100)
+                if stats["total"] > 0
+                else 0
             )
 
             device_results.append(
@@ -1706,7 +1724,9 @@ def get_database_metrics():  # pylint: disable=too-many-branches,too-many-statem
                 text("SELECT count(*) as total_connections FROM pg_stat_activity")
             ).fetchone()
 
-            max_connections = session.execute(text("SHOW max_connections")).fetchone()
+            max_connections = session.execute(
+                text("SHOW max_connections")
+            ).fetchone()
 
             if connection_stats and total_connections and max_connections:
                 active = connection_stats[0]
@@ -1973,7 +1993,9 @@ def get_all_profiles() -> list:
     """Return all NextDNSProfile rows (enabled and disabled)."""
     session = session_factory()
     try:
-        return session.query(NextDNSProfile).order_by(NextDNSProfile.profile_id).all()
+        return (
+            session.query(NextDNSProfile).order_by(NextDNSProfile.profile_id).all()
+        )
     except SQLAlchemyError as e:
         logger.error(f"❌ Error reading profiles: {e}")
         return []
@@ -2058,7 +2080,10 @@ def delete_profile_data(profile_id: str) -> dict:
             f"🗑️  Profile '{profile_id}' data cleaned up: "
             f"{logs_deleted} DNS logs, {fetch_deleted} fetch status rows deleted"
         )
-        return {"dns_logs_deleted": logs_deleted, "fetch_status_deleted": fetch_deleted}
+        return {
+            "dns_logs_deleted": logs_deleted,
+            "fetch_status_deleted": fetch_deleted,
+        }
     except SQLAlchemyError as e:
         session.rollback()
         logger.error(f"❌ Error deleting data for profile '{profile_id}': {e}")

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 from datetime import datetime, timezone, timedelta
+from typing import Optional
 
 from sqlalchemy import (
     create_engine,
@@ -1814,3 +1815,351 @@ def get_database_metrics():  # pylint: disable=too-many-branches,too-many-statem
         }
     finally:
         session.close()
+
+
+# ---------------------------------------------------------------------------
+# System Settings — generic key/value store (shared foundation with #115)
+# ---------------------------------------------------------------------------
+
+
+class SystemSetting(Base):
+    """Generic key/value settings table.
+
+    Used to store application-level configuration that previously lived in
+    environment variables.  The first key populated here is ``nextdns_api_key``;
+    additional keys will be added in issue #115 (general system settings).
+    """
+
+    __tablename__ = "system_settings"
+
+    key = Column(String(100), primary_key=True)
+    value = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# NextDNS Profiles — managed profile list (replaces PROFILE_IDS env var)
+# ---------------------------------------------------------------------------
+
+
+class NextDNSProfile(Base):
+    """Stores the set of NextDNS profiles the scheduler should fetch.
+
+    Profiles are managed via the ``/settings/nextdns/profiles`` API rather
+    than the ``PROFILE_IDS`` environment variable.  The env var is still read
+    on first boot to seed this table (see ``migrate_config_from_env``).
+    """
+
+    __tablename__ = "nextdns_profiles"
+
+    profile_id = Column(String(50), primary_key=True)
+    enabled = Column(Boolean, default=True, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generic settings helpers
+# ---------------------------------------------------------------------------
+
+
+def get_setting(key: str) -> Optional[str]:
+    """Return the value for *key* from system_settings, or None."""
+    session = session_factory()
+    try:
+        row = session.query(SystemSetting).filter_by(key=key).first()
+        return row.value if row else None
+    except SQLAlchemyError as e:
+        logger.error(f"❌ Error reading setting '{key}': {e}")
+        return None
+    finally:
+        session.close()
+
+
+def set_setting(key: str, value: str) -> bool:
+    """Upsert *key* → *value* in system_settings."""
+    session = session_factory()
+    try:
+        row = session.query(SystemSetting).filter_by(key=key).first()
+        if row:
+            row.value = value
+            row.updated_at = datetime.now(timezone.utc)
+        else:
+            row = SystemSetting(key=key, value=value)
+            session.add(row)
+        session.commit()
+        logger.debug(f"✅ Setting '{key}' saved")
+        return True
+    except SQLAlchemyError as e:
+        session.rollback()
+        logger.error(f"❌ Error saving setting '{key}': {e}")
+        return False
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# NextDNS API key helpers
+# ---------------------------------------------------------------------------
+
+NEXTDNS_API_KEY_SETTING = "nextdns_api_key"
+
+
+def get_nextdns_api_key() -> Optional[str]:
+    """Return the stored NextDNS API key, or fall back to the env var."""
+    key = get_setting(NEXTDNS_API_KEY_SETTING)
+    if key:
+        return key
+    # Fallback: env var (used before first migration or in legacy setups)
+    return os.getenv("API_KEY")
+
+
+def set_nextdns_api_key(api_key: str) -> bool:
+    """Persist the NextDNS API key to the database."""
+    return set_setting(NEXTDNS_API_KEY_SETTING, api_key)
+
+
+# ---------------------------------------------------------------------------
+# NextDNS profile helpers
+# ---------------------------------------------------------------------------
+
+
+def get_active_profile_ids() -> list:
+    """Return profile_ids for all *enabled* profiles in the DB.
+
+    Falls back to env var ``PROFILE_IDS`` if the table is empty (e.g. before
+    the first ``migrate_config_from_env`` run).
+    """
+    session = session_factory()
+    try:
+        rows = (
+            session.query(NextDNSProfile)
+            .filter_by(enabled=True)
+            .order_by(NextDNSProfile.profile_id)
+            .all()
+        )
+        if rows:
+            return [r.profile_id for r in rows]
+    except SQLAlchemyError as e:
+        logger.error(f"❌ Error reading active profiles: {e}")
+    finally:
+        session.close()
+
+    # Fallback to env var
+    env_ids = os.getenv("PROFILE_IDS", "")
+    return [p.strip() for p in env_ids.split(",") if p.strip()]
+
+
+def get_all_profiles() -> list:
+    """Return all NextDNSProfile rows (enabled and disabled)."""
+    session = session_factory()
+    try:
+        return session.query(NextDNSProfile).order_by(NextDNSProfile.profile_id).all()
+    except SQLAlchemyError as e:
+        logger.error(f"❌ Error reading profiles: {e}")
+        return []
+    finally:
+        session.close()
+
+
+def get_profile(profile_id: str) -> Optional[object]:
+    """Return a single NextDNSProfile row or None."""
+    session = session_factory()
+    try:
+        return session.query(NextDNSProfile).filter_by(profile_id=profile_id).first()
+    except SQLAlchemyError as e:
+        logger.error(f"❌ Error reading profile '{profile_id}': {e}")
+        return None
+    finally:
+        session.close()
+
+
+def add_profile(profile_id: str) -> bool:
+    """Insert a new enabled profile.  Returns False if it already exists."""
+    session = session_factory()
+    try:
+        existing = (
+            session.query(NextDNSProfile).filter_by(profile_id=profile_id).first()
+        )
+        if existing:
+            logger.warning(f"⚠️  Profile '{profile_id}' already exists")
+            return False
+        session.add(NextDNSProfile(profile_id=profile_id, enabled=True))
+        session.commit()
+        logger.info(f"✅ Profile '{profile_id}' added")
+        return True
+    except SQLAlchemyError as e:
+        session.rollback()
+        logger.error(f"❌ Error adding profile '{profile_id}': {e}")
+        return False
+    finally:
+        session.close()
+
+
+def update_profile_enabled(profile_id: str, enabled: bool) -> bool:
+    """Enable or disable a profile.  Returns False if not found."""
+    session = session_factory()
+    try:
+        row = session.query(NextDNSProfile).filter_by(profile_id=profile_id).first()
+        if not row:
+            return False
+        row.enabled = enabled
+        row.updated_at = datetime.now(timezone.utc)
+        session.commit()
+        state = "enabled" if enabled else "disabled"
+        logger.info(f"✅ Profile '{profile_id}' {state}")
+        return True
+    except SQLAlchemyError as e:
+        session.rollback()
+        logger.error(f"❌ Error updating profile '{profile_id}': {e}")
+        return False
+    finally:
+        session.close()
+
+
+def delete_profile_data(profile_id: str) -> dict:
+    """Remove all DNS logs and fetch status for *profile_id*.
+
+    Returns a dict with counts of deleted rows per table.
+    """
+    session = session_factory()
+    try:
+        logs_deleted = (
+            session.query(DNSLog)
+            .filter(DNSLog.profile_id == profile_id)
+            .delete(synchronize_session=False)
+        )
+        fetch_deleted = (
+            session.query(FetchStatus)
+            .filter(FetchStatus.profile_id == profile_id)
+            .delete(synchronize_session=False)
+        )
+        session.commit()
+        logger.info(
+            f"🗑️  Profile '{profile_id}' data cleaned up: "
+            f"{logs_deleted} DNS logs, {fetch_deleted} fetch status rows deleted"
+        )
+        return {"dns_logs_deleted": logs_deleted, "fetch_status_deleted": fetch_deleted}
+    except SQLAlchemyError as e:
+        session.rollback()
+        logger.error(f"❌ Error deleting data for profile '{profile_id}': {e}")
+        return {"dns_logs_deleted": 0, "fetch_status_deleted": 0}
+    finally:
+        session.close()
+
+
+def delete_profile(profile_id: str, delete_data: bool = True) -> dict:
+    """Remove a profile from nextdns_profiles (and optionally its data).
+
+    Args:
+        profile_id: The profile to remove.
+        delete_data: If True (default), also delete DNS logs and fetch status.
+
+    Returns:
+        dict with keys ``deleted`` (bool) and cleanup counts.
+    """
+    cleanup = {"dns_logs_deleted": 0, "fetch_status_deleted": 0}
+    if delete_data:
+        cleanup = delete_profile_data(profile_id)
+
+    session = session_factory()
+    try:
+        deleted = (
+            session.query(NextDNSProfile)
+            .filter_by(profile_id=profile_id)
+            .delete(synchronize_session=False)
+        )
+        session.commit()
+        if deleted:
+            logger.info(f"🗑️  Profile '{profile_id}' removed from nextdns_profiles")
+            return {"deleted": True, **cleanup}
+        logger.warning(f"⚠️  Profile '{profile_id}' not found for deletion")
+        return {"deleted": False, **cleanup}
+    except SQLAlchemyError as e:
+        session.rollback()
+        logger.error(f"❌ Error deleting profile '{profile_id}': {e}")
+        return {"deleted": False, **cleanup}
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# One-time startup migration from environment variables
+# ---------------------------------------------------------------------------
+
+
+def migrate_config_from_env() -> bool:
+    """Seed system_settings and nextdns_profiles from env vars if both are empty.
+
+    This runs once on first boot after the migration adds the new tables.
+    Subsequent boots skip seeding because rows already exist.
+
+    Returns:
+        True if seeding was performed, False if tables already had data.
+    """
+    session = session_factory()
+    try:
+        has_settings = session.query(SystemSetting).first() is not None
+        has_profiles = session.query(NextDNSProfile).first() is not None
+    except SQLAlchemyError as e:
+        logger.error(f"❌ migrate_config_from_env: cannot query tables: {e}")
+        return False
+    finally:
+        session.close()
+
+    if has_settings and has_profiles:
+        logger.debug("🧱 Config tables already populated — skipping env migration")
+        return False
+
+    seeded = False
+
+    # Seed API key
+    if not has_settings:
+        api_key = os.getenv("API_KEY")
+        if api_key:
+            set_nextdns_api_key(api_key)
+            logger.info("🔑 Migrated NextDNS API key from env to system_settings")
+            seeded = True
+        else:
+            logger.warning(
+                "⚠️  API_KEY env var not set — NextDNS API key not migrated. "
+                "Set it via PUT /settings/nextdns/api-key after startup."
+            )
+
+    # Seed profiles
+    if not has_profiles:
+        env_ids = os.getenv("PROFILE_IDS", "")
+        profile_ids = [p.strip() for p in env_ids.split(",") if p.strip()]
+        if profile_ids:
+            for pid in profile_ids:
+                add_profile(pid)
+            logger.info(
+                f"🧱 Migrated {len(profile_ids)} profile(s) from PROFILE_IDS env to DB"
+            )
+            seeded = True
+        else:
+            logger.warning(
+                "⚠️  PROFILE_IDS env var not set — no profiles migrated. "
+                "Add profiles via POST /settings/nextdns/profiles after startup."
+            )
+
+    return seeded

--- a/backend/profile_service.py
+++ b/backend/profile_service.py
@@ -8,7 +8,9 @@ from models import get_nextdns_api_key, get_active_profile_ids
 logger = get_logger(__name__)
 
 
-def _create_error_profile_info(profile_id: str, name_suffix: str, error: str) -> Dict:
+def _create_error_profile_info(
+    profile_id: str, name_suffix: str, error: str
+) -> Dict:
     """Helper function to create error profile information."""
     return {
         "id": profile_id,
@@ -21,7 +23,9 @@ def _handle_api_response(response: requests.Response, profile_id: str) -> Dict:
     """Helper function to handle API response based on status code."""
     if response.status_code == 200:
         profile_data = response.json().get("data", {})
-        logger.debug(f"✅ Profile {profile_id}: {profile_data.get('name', 'Unknown')}")
+        logger.debug(
+            f"✅ Profile {profile_id}: {profile_data.get('name', 'Unknown')}"
+        )
         return {
             "id": profile_id,
             "name": profile_data.get("name", f"Profile {profile_id}"),

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -19,7 +19,9 @@ from logging_config import get_logger
 logger = get_logger(__name__)
 
 FETCH_INTERVAL = int(os.getenv("FETCH_INTERVAL", "60"))  # Default to 60 minutes
-FETCH_LIMIT = int(os.getenv("FETCH_LIMIT", "100"))  # Default to 100 records per request
+FETCH_LIMIT = int(
+    os.getenv("FETCH_LIMIT", "100")
+)  # Default to 100 records per request
 
 
 def fetch_logs():  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
@@ -94,7 +96,9 @@ def fetch_logs():  # pylint: disable=too-many-locals,too-many-branches,too-many-
                 logger.info(f"🔄 Profile {profile_id}: fetched {len(logs)} DNS logs")
 
                 if not logs:
-                    logger.info(f"✅ Profile {profile_id}: no new records to process")
+                    logger.info(
+                        f"✅ Profile {profile_id}: no new records to process"
+                    )
                     successful_profiles += 1
                     continue
 

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -9,6 +9,8 @@ from models import (
     get_total_record_count,
     get_last_fetch_timestamp,
     update_fetch_status,
+    get_nextdns_api_key,
+    get_active_profile_ids,
 )
 
 # Set up logging
@@ -16,186 +18,173 @@ from logging_config import get_logger
 
 logger = get_logger(__name__)
 
-API_KEY = os.getenv("API_KEY")
-PROFILE_IDS = os.getenv("PROFILE_IDS")
 FETCH_INTERVAL = int(os.getenv("FETCH_INTERVAL", "60"))  # Default to 60 minutes
 FETCH_LIMIT = int(os.getenv("FETCH_LIMIT", "100"))  # Default to 100 records per request
 
-# Parse profile IDs
-profile_ids = []
-if PROFILE_IDS:
-    profile_ids = [pid.strip() for pid in PROFILE_IDS.split(",") if pid.strip()]
+
+def fetch_logs():  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
+    """Fetch logs from NextDNS API with timestamp-based incremental fetching for multiple profiles.
+
+    API key and profile list are read from the database on every invocation so
+    that changes made via the settings API take effect on the next scheduled
+    run without requiring a restart.
+    """
+    # Re-read config from DB on every cycle (supports dynamic management)
+    api_key = get_nextdns_api_key()
+    profile_ids = get_active_profile_ids()
+
+    if not api_key or not profile_ids:
+        logger.warning("⚠️  Missing NextDNS API credentials — skipping fetch cycle")
+        if not api_key:
+            logger.info("💡 Set the API key via PUT /settings/nextdns/api-key")
+        if not profile_ids:
+            logger.info("💡 Add profiles via POST /settings/nextdns/profiles")
+        return
+
+    # Log initial database state
+    initial_count = get_total_record_count()
     logger.info(
-        f"🧱 Configured {len(profile_ids)} profile(s): {', '.join(profile_ids)}"
-    )
-else:
-    logger.warning("⚠️  Missing NextDNS profile IDs!")
-    logger.info("💡 Please set PROFILE_IDS environment variable (comma-separated)")
-    logger.info("💡 Example: PROFILE_IDS=abc123,def456,ghi789")
-
-# Check if required variables are set
-if not API_KEY or not profile_ids:
-    logger.warning("⚠️  Missing NextDNS API credentials!")
-    logger.info("💡 Please set API_KEY and PROFILE_IDS environment variables")
-    logger.warning("🧱 Scheduler will not start - no logs will be fetched")
-    scheduler = None  # pylint: disable=invalid-name
-else:
-    logger.info(
-        f"✅ NextDNS API configured with API key and {len(profile_ids)} profile(s)"
+        f"🔄 Starting multi-profile NextDNS log fetch (Database has {initial_count:,} records)"
     )
 
-    def fetch_logs():  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
-        """Fetch logs from NextDNS API with timestamp-based incremental fetching for multiple profiles."""
-        # Log initial database state
-        initial_count = get_total_record_count()
-        logger.info(
-            f"🔄 Starting multi-profile NextDNS log fetch (Database has {initial_count:,} records)"
-        )
+    total_added = 0
+    total_skipped = 0
+    successful_profiles = 0
+    failed_profiles = 0
 
-        total_added = 0
-        total_skipped = 0
-        successful_profiles = 0
-        failed_profiles = 0
+    # Fetch from each profile
+    for profile_id in profile_ids:  # pylint: disable=too-many-nested-blocks
+        try:
+            logger.info(f"🧱 Processing profile: {profile_id}")
 
-        # Fetch from each profile
-        for profile_id in profile_ids:  # pylint: disable=too-many-nested-blocks
-            try:
-                logger.info(f"🧱 Processing profile: {profile_id}")
+            # Get last fetch timestamp for this specific profile
+            last_fetch = get_last_fetch_timestamp(profile_id)
 
-                # Get last fetch timestamp for this specific profile
-                last_fetch = get_last_fetch_timestamp(profile_id)
+            headers = {"X-Api-Key": api_key}
+            nextdns_api_url = f"https://api.nextdns.io/profiles/{profile_id}/logs"
 
-                headers = {"X-Api-Key": API_KEY}
-                nextdns_api_url = f"https://api.nextdns.io/profiles/{profile_id}/logs"
+            # Build parameters for incremental fetching
+            if last_fetch:
+                # Fetch records newer than last fetch (with small overlap for safety)
+                from_time = last_fetch.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                params = {
+                    "from": from_time,
+                    "to": "now",
+                    "raw": "false",
+                    "limit": FETCH_LIMIT,
+                }
+                logger.info(
+                    f"📅 Profile {profile_id}: incremental fetch from {from_time}"
+                )
+            else:
+                # First fetch - get last hour of data
+                params = {
+                    "from": "-1h",
+                    "to": "now",
+                    "raw": "false",
+                    "limit": FETCH_LIMIT,
+                }
+                logger.info(f"📅 Profile {profile_id}: initial fetch from past hour")
 
-                # Build parameters for incremental fetching
-                if last_fetch:
-                    # Fetch records newer than last fetch (with small overlap for safety)
-                    from_time = last_fetch.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                    params = {
-                        "from": from_time,
-                        "to": "now",
-                        "raw": "false",
-                        "limit": FETCH_LIMIT,
-                    }
-                    logger.info(
-                        f"📅 Profile {profile_id}: incremental fetch from {from_time}"
-                    )
-                else:
-                    # First fetch - get last hour of data
-                    params = {
-                        "from": "-1h",
-                        "to": "now",
-                        "raw": "false",
-                        "limit": FETCH_LIMIT,
-                    }
-                    logger.info(
-                        f"📅 Profile {profile_id}: initial fetch from past hour"
-                    )
+            logger.debug(f"🌐 Making API request to: {nextdns_api_url}")
+            response = requests.get(nextdns_api_url, headers=headers, params=params)
 
-                logger.debug(f"🌐 Making API request to: {nextdns_api_url}")
-                response = requests.get(nextdns_api_url, headers=headers, params=params)
+            if response.status_code == 200:
+                logs = response.json().get("data", [])
+                logger.info(f"🔄 Profile {profile_id}: fetched {len(logs)} DNS logs")
 
-                if response.status_code == 200:
-                    logs = response.json().get("data", [])
-                    logger.info(
-                        f"🔄 Profile {profile_id}: fetched {len(logs)} DNS logs"
-                    )
-
-                    if not logs:
-                        logger.info(
-                            f"✅ Profile {profile_id}: no new records to process"
-                        )
-                        successful_profiles += 1
-                        continue
-
-                    # Process logs with duplicate tracking
-                    profile_added = 0
-                    profile_skipped = 0
-                    latest_timestamp = None
-
-                    for log in logs:
-                        # Ensure the log has the profile_id tagged
-                        log["profile_id"] = profile_id
-
-                        record_id, is_new = add_log(log)
-                        if record_id:
-                            if is_new:
-                                profile_added += 1
-                                # Track the latest timestamp for incremental fetching
-                                log_timestamp_str = log.get("timestamp")
-                                if log_timestamp_str:
-                                    log_timestamp = datetime.fromisoformat(
-                                        log_timestamp_str.replace("Z", "+00:00")
-                                    )
-                                    if (
-                                        not latest_timestamp
-                                        or log_timestamp > latest_timestamp
-                                    ):
-                                        latest_timestamp = log_timestamp
-                            else:
-                                profile_skipped += 1
-                        else:
-                            logger.warning(
-                                f"⚠️  Profile {profile_id}: failed to process log "
-                                f"for domain: {log.get('domain')}"
-                            )
-
-                    # Update fetch status with latest timestamp for this profile
-                    if latest_timestamp and profile_added > 0:
-                        update_fetch_status(profile_id, latest_timestamp, profile_added)
-                        logger.debug(f"📅 Profile {profile_id}: updated fetch status")
-
-                    # Log profile statistics
-                    logger.info(
-                        f"💾 Profile {profile_id}: {profile_added} NEW records added, "
-                        f"{profile_skipped} duplicates skipped"
-                    )
-
-                    total_added += profile_added
-                    total_skipped += profile_skipped
+                if not logs:
+                    logger.info(f"✅ Profile {profile_id}: no new records to process")
                     successful_profiles += 1
+                    continue
 
-                else:
-                    logger.error(
-                        f"⚠️  Profile {profile_id}: API returned status "
-                        f"{response.status_code}: {response.text}"
-                    )
-                    failed_profiles += 1
+                # Process logs with duplicate tracking
+                profile_added = 0
+                profile_skipped = 0
+                latest_timestamp = None
 
-            except requests.exceptions.RequestException as e:
-                logger.error(f"❌ Profile {profile_id}: error fetching logs: {e}")
+                for log in logs:
+                    # Ensure the log has the profile_id tagged
+                    log["profile_id"] = profile_id
+
+                    record_id, is_new = add_log(log)
+                    if record_id:
+                        if is_new:
+                            profile_added += 1
+                            # Track the latest timestamp for incremental fetching
+                            log_timestamp_str = log.get("timestamp")
+                            if log_timestamp_str:
+                                log_timestamp = datetime.fromisoformat(
+                                    log_timestamp_str.replace("Z", "+00:00")
+                                )
+                                if (
+                                    not latest_timestamp
+                                    or log_timestamp > latest_timestamp
+                                ):
+                                    latest_timestamp = log_timestamp
+                        else:
+                            profile_skipped += 1
+                    else:
+                        logger.warning(
+                            f"⚠️  Profile {profile_id}: failed to process log "
+                            f"for domain: {log.get('domain')}"
+                        )
+
+                # Update fetch status with latest timestamp for this profile
+                if latest_timestamp and profile_added > 0:
+                    update_fetch_status(profile_id, latest_timestamp, profile_added)
+                    logger.debug(f"📅 Profile {profile_id}: updated fetch status")
+
+                # Log profile statistics
+                logger.info(
+                    f"💾 Profile {profile_id}: {profile_added} NEW records added, "
+                    f"{profile_skipped} duplicates skipped"
+                )
+
+                total_added += profile_added
+                total_skipped += profile_skipped
+                successful_profiles += 1
+
+            else:
+                logger.error(
+                    f"⚠️  Profile {profile_id}: API returned status "
+                    f"{response.status_code}: {response.text}"
+                )
                 failed_profiles += 1
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.error(f"❌ Profile {profile_id}: unexpected error: {e}")
-                failed_profiles += 1
 
-        # Log comprehensive statistics for all profiles
-        final_count = get_total_record_count()
-        logger.info("🏁 Multi-profile fetch completed:")
-        logger.info(
-            f"📊 Total: {total_added} NEW records added, {total_skipped} duplicates skipped"
-        )
-        logger.info(
-            f"📊 Profiles: {successful_profiles} successful, {failed_profiles} failed"
-        )
-        logger.info(
-            f"📊 Database now has {final_count:,} total records (+{total_added:,} new this fetch)"
-        )
+        except requests.exceptions.RequestException as e:
+            logger.error(f"❌ Profile {profile_id}: error fetching logs: {e}")
+            failed_profiles += 1
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error(f"❌ Profile {profile_id}: unexpected error: {e}")
+            failed_profiles += 1
 
-        if total_skipped > 0:
-            logger.info("🔄 Duplicate prevention working across all profiles")
-
-    # Initialize and start scheduler
-    scheduler = BackgroundScheduler()  # pylint: disable=invalid-name
-    scheduler.add_job(fetch_logs, "interval", minutes=FETCH_INTERVAL)
-    scheduler.start()
+    # Log comprehensive statistics for all profiles
+    final_count = get_total_record_count()
+    logger.info("🏁 Multi-profile fetch completed:")
     logger.info(
-        f"🔄 NextDNS log fetching scheduler started (runs every {FETCH_INTERVAL} minutes)"
+        f"📊 Total: {total_added} NEW records added, {total_skipped} duplicates skipped"
     )
     logger.info(
-        f"🕰️ Fetch interval configured: {FETCH_INTERVAL} minutes ({FETCH_INTERVAL/60:.1f} hours)"
+        f"📊 Profiles: {successful_profiles} successful, {failed_profiles} failed"
     )
-    logger.info(f"📊 Fetch limit configured: {FETCH_LIMIT} records per request")
+    logger.info(
+        f"📊 Database now has {final_count:,} total records (+{total_added:,} new this fetch)"
+    )
 
-    # Scheduler is now available as 'scheduler' variable
+    if total_skipped > 0:
+        logger.info("🔄 Duplicate prevention working across all profiles")
+
+
+# Initialize and start scheduler
+scheduler = BackgroundScheduler()  # pylint: disable=invalid-name
+scheduler.add_job(fetch_logs, "interval", minutes=FETCH_INTERVAL)
+scheduler.start()
+logger.info(
+    f"🔄 NextDNS log fetching scheduler started (runs every {FETCH_INTERVAL} minutes)"
+)
+logger.info(
+    f"🕰️ Fetch interval configured: {FETCH_INTERVAL} minutes ({FETCH_INTERVAL/60:.1f} hours)"
+)
+logger.info(f"📊 Fetch limit configured: {FETCH_LIMIT} records per request")
+logger.info("🧱 API key and profiles are read from DB on each fetch cycle")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -40,7 +40,9 @@ def test_db():
     Base.metadata.create_all(engine)
 
     # Create session factory
-    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    TestingSessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=engine
+    )
     session = TestingSessionLocal()
 
     try:

--- a/backend/tests/integration/test_api_logs.py
+++ b/backend/tests/integration/test_api_logs.py
@@ -147,7 +147,9 @@ def test_get_logs_with_exclude_domains(test_client, populated_test_db, monkeypat
 
     client = TestClient(app)
 
-    response = client.get("/logs?exclude=test0.example.com&exclude=test1.example.com")
+    response = client.get(
+        "/logs?exclude=test0.example.com&exclude=test1.example.com"
+    )
 
     assert response.status_code == status.HTTP_200_OK
     data = response.json()

--- a/backend/tests/integration/test_api_settings.py
+++ b/backend/tests/integration/test_api_settings.py
@@ -101,7 +101,9 @@ class TestApiKeyEndpoints:
         response = test_client.get("/settings/nextdns/api-key")
         assert response.status_code in [200, 401, 403]
 
-        response = test_client.put("/settings/nextdns/api-key", json={"api_key": "x"})
+        response = test_client.put(
+            "/settings/nextdns/api-key", json={"api_key": "x"}
+        )
         assert response.status_code in [200, 400, 401, 403, 422, 500]
 
 

--- a/backend/tests/integration/test_api_settings.py
+++ b/backend/tests/integration/test_api_settings.py
@@ -1,0 +1,315 @@
+# file: backend/tests/integration/test_api_settings.py
+"""
+🧱 Integration Tests for NextDNS Settings API Endpoints
+
+Testing the settings API LEGO bricks — /settings/nextdns/api-key and
+/settings/nextdns/profiles.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Mark all tests in this module as integration tests
+pytestmark = pytest.mark.integration
+
+
+class TestApiKeyEndpoints:
+    """Test GET/PUT /settings/nextdns/api-key."""
+
+    def test_get_api_key_unconfigured(self, test_client):
+        """Returns configured=False when no API key is stored."""
+        with patch("main.get_nextdns_api_key", return_value=None):
+            response = test_client.get(
+                "/settings/nextdns/api-key",
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["configured"] is False
+        assert data.get("masked_key") is None
+
+    def test_get_api_key_configured(self, test_client):
+        """Returns configured=True and a masked key when a key is stored."""
+        with patch("main.get_nextdns_api_key", return_value="supersecretkey1234"):
+            response = test_client.get(
+                "/settings/nextdns/api-key",
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["configured"] is True
+        assert data["masked_key"] is not None
+        # Last 4 chars are visible
+        assert data["masked_key"].endswith("1234")
+        # Full key is not exposed
+        assert "supersecretkey" not in data["masked_key"]
+
+    def test_put_api_key_empty_body(self, test_client):
+        """Rejects empty api_key."""
+        response = test_client.put(
+            "/settings/nextdns/api-key",
+            json={"api_key": "   "},
+            headers={"X-API-Key": "test-api-key-123"},
+        )
+        assert response.status_code == 400
+
+    def test_put_api_key_invalid_key(self, test_client):
+        """Rejects a key that NextDNS API refuses."""
+        with patch("main._validate_nextdns_api_key", return_value=False):
+            response = test_client.put(
+                "/settings/nextdns/api-key",
+                json={"api_key": "bad-key"},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 422
+
+    def test_put_api_key_valid_key(self, test_client):
+        """Accepts and persists a valid key."""
+        with (
+            patch("main._validate_nextdns_api_key", return_value=True),
+            patch("main.set_nextdns_api_key", return_value=True),
+        ):
+            response = test_client.put(
+                "/settings/nextdns/api-key",
+                json={"api_key": "valid-key-abcd1234"},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["configured"] is True
+        assert data["masked_key"].endswith("1234")
+
+    def test_put_api_key_db_failure(self, test_client):
+        """Returns 500 when DB write fails."""
+        with (
+            patch("main._validate_nextdns_api_key", return_value=True),
+            patch("main.set_nextdns_api_key", return_value=False),
+        ):
+            response = test_client.put(
+                "/settings/nextdns/api-key",
+                json={"api_key": "valid-key-abcd1234"},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 500
+
+    def test_api_key_endpoints_require_auth(self, test_client):
+        """Endpoints return 401/403 (auth enabled) or 200 (auth disabled) without a key.
+
+        In the test environment AUTH_ENABLED=false so 200 is expected;
+        in production with AUTH_ENABLED=true a 401/403 is returned.
+        """
+        response = test_client.get("/settings/nextdns/api-key")
+        assert response.status_code in [200, 401, 403]
+
+        response = test_client.put("/settings/nextdns/api-key", json={"api_key": "x"})
+        assert response.status_code in [200, 400, 401, 403, 422, 500]
+
+
+class TestProfileSettingsEndpoints:
+    """Test CRUD on /settings/nextdns/profiles."""
+
+    def _make_profile_row(self, profile_id, enabled=True):
+        row = MagicMock()
+        row.profile_id = profile_id
+        row.enabled = enabled
+        row.created_at = None
+        row.updated_at = None
+        return row
+
+    def test_list_profiles_empty(self, test_client):
+        """Returns an empty list when no profiles are configured."""
+        with patch("main.get_all_profiles", return_value=[]):
+            response = test_client.get(
+                "/settings/nextdns/profiles",
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["profiles"] == []
+        assert data["total"] == 0
+
+    def test_list_profiles_with_data(self, test_client):
+        """Returns all profiles (enabled and disabled)."""
+        rows = [
+            self._make_profile_row("p1", enabled=True),
+            self._make_profile_row("p2", enabled=False),
+        ]
+        with patch("main.get_all_profiles", return_value=rows):
+            response = test_client.get(
+                "/settings/nextdns/profiles",
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        ids = [p["profile_id"] for p in data["profiles"]]
+        assert "p1" in ids
+        assert "p2" in ids
+
+    def test_add_profile_no_api_key(self, test_client):
+        """Returns 422 when no NextDNS API key is configured."""
+        with patch("main.get_nextdns_api_key", return_value=None):
+            response = test_client.post(
+                "/settings/nextdns/profiles",
+                json={"profile_id": "new-profile"},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 422
+
+    def test_add_profile_not_found_on_nextdns(self, test_client):
+        """Returns 422 when profile does not exist on NextDNS."""
+        with (
+            patch("main.get_nextdns_api_key", return_value="some-key"),
+            patch("main.get_profile_info", return_value={"error": "Not found"}),
+        ):
+            response = test_client.post(
+                "/settings/nextdns/profiles",
+                json={"profile_id": "bad-profile"},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 422
+
+    def test_add_profile_already_exists(self, test_client):
+        """Returns 409 when profile already exists in DB."""
+        with (
+            patch("main.get_nextdns_api_key", return_value="some-key"),
+            patch("main.get_profile_info", return_value={"id": "p1", "name": "P1"}),
+            patch("main.add_profile", return_value=False),
+        ):
+            response = test_client.post(
+                "/settings/nextdns/profiles",
+                json={"profile_id": "p1"},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 409
+
+    def test_add_profile_success(self, test_client):
+        """Successfully adds a new profile."""
+        row = self._make_profile_row("new-profile")
+        with (
+            patch("main.get_nextdns_api_key", return_value="some-key"),
+            patch(
+                "main.get_profile_info",
+                return_value={"id": "new-profile", "name": "New"},
+            ),
+            patch("main.add_profile", return_value=True),
+            patch("main.get_profile", return_value=row),
+        ):
+            response = test_client.post(
+                "/settings/nextdns/profiles",
+                json={"profile_id": "new-profile"},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 201
+        assert response.json()["profile_id"] == "new-profile"
+        assert response.json()["enabled"] is True
+
+    def test_add_profile_empty_id(self, test_client):
+        """Returns 400 for empty profile_id."""
+        response = test_client.post(
+            "/settings/nextdns/profiles",
+            json={"profile_id": "  "},
+            headers={"X-API-Key": "test-api-key-123"},
+        )
+        assert response.status_code == 400
+
+    def test_update_profile_enable(self, test_client):
+        """Enables an existing profile."""
+        row = self._make_profile_row("p1", enabled=True)
+        with (
+            patch("main.update_profile_enabled", return_value=True),
+            patch("main.get_profile", return_value=row),
+        ):
+            response = test_client.put(
+                "/settings/nextdns/profiles/p1",
+                json={"enabled": True},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 200
+        assert response.json()["enabled"] is True
+
+    def test_update_profile_not_found(self, test_client):
+        """Returns 404 when profile does not exist."""
+        with patch("main.update_profile_enabled", return_value=False):
+            response = test_client.put(
+                "/settings/nextdns/profiles/ghost",
+                json={"enabled": True},
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 404
+
+    def test_delete_profile_success(self, test_client):
+        """Deletes a profile and returns cleanup counts."""
+        with patch(
+            "main.delete_profile",
+            return_value={
+                "deleted": True,
+                "dns_logs_deleted": 42,
+                "fetch_status_deleted": 1,
+            },
+        ):
+            response = test_client.delete(
+                "/settings/nextdns/profiles/p1",
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is True
+        assert data["dns_logs_deleted"] == 42
+        assert data["fetch_status_deleted"] == 1
+
+    def test_delete_profile_not_found(self, test_client):
+        """Returns 404 when profile does not exist."""
+        with patch(
+            "main.delete_profile",
+            return_value={
+                "deleted": False,
+                "dns_logs_deleted": 0,
+                "fetch_status_deleted": 0,
+            },
+        ):
+            response = test_client.delete(
+                "/settings/nextdns/profiles/ghost",
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        assert response.status_code == 404
+
+    def test_delete_profile_skip_purge(self, test_client):
+        """Passes purge_data=False when ?purge_data=false is set."""
+        with patch(
+            "main.delete_profile",
+            return_value={
+                "deleted": True,
+                "dns_logs_deleted": 0,
+                "fetch_status_deleted": 0,
+            },
+        ) as mock_delete:
+            test_client.delete(
+                "/settings/nextdns/profiles/p1?purge_data=false",
+                headers={"X-API-Key": "test-api-key-123"},
+            )
+        mock_delete.assert_called_once_with("p1", delete_data=False)
+
+    def test_profiles_endpoints_require_auth(self, test_client):
+        """Endpoints return 401/403 (auth enabled) or 200 (auth disabled) without a key.
+
+        In the test environment AUTH_ENABLED=false so 200 is expected;
+        in production with AUTH_ENABLED=true a 401/403 is returned.
+        """
+        assert test_client.get("/settings/nextdns/profiles").status_code in [
+            200,
+            401,
+            403,
+        ]
+        assert test_client.post(
+            "/settings/nextdns/profiles", json={"profile_id": "x"}
+        ).status_code in [200, 400, 401, 403, 422]
+        assert test_client.put(
+            "/settings/nextdns/profiles/x", json={"enabled": True}
+        ).status_code in [200, 401, 403, 404]
+        assert test_client.delete("/settings/nextdns/profiles/x").status_code in [
+            200,
+            401,
+            403,
+            404,
+        ]

--- a/backend/tests/integration/test_api_stats.py
+++ b/backend/tests/integration/test_api_stats.py
@@ -56,7 +56,9 @@ def test_get_stats_overview_with_time_range(
 
 
 @pytest.mark.integration
-def test_get_stats_overview_with_profile(test_client, populated_test_db, monkeypatch):
+def test_get_stats_overview_with_profile(
+    test_client, populated_test_db, monkeypatch
+):
     """Test GET /stats/overview with profile filter."""
     monkeypatch.setenv("AUTH_ENABLED", "false")
 

--- a/backend/tests/unit/test_auth_functions.py
+++ b/backend/tests/unit/test_auth_functions.py
@@ -117,7 +117,9 @@ async def test_get_current_user_token_without_username(monkeypatch):
 
         # Create token without 'sub' field
         token = create_access_token({"role": "admin"})  # Missing 'sub'
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials=token
+        )
 
         # Should raise 401 when username (sub) is missing
         with pytest.raises(HTTPException) as exc_info:
@@ -229,7 +231,9 @@ async def test_get_current_user_optional_token_without_username(monkeypatch):
 
         # Create token without 'sub' field
         token = create_access_token({"role": "admin"})
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials=token
+        )
 
         # Should return None when username is missing
         result = await get_current_user_optional(credentials=credentials)
@@ -258,7 +262,9 @@ async def test_get_current_user_optional_valid_token(monkeypatch):
 
         # Create valid token
         token = create_access_token({"sub": "testuser"})
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials=token
+        )
 
         # Should return username
         result = await get_current_user_optional(credentials=credentials)
@@ -319,7 +325,9 @@ def test_init_auth_when_disabled(monkeypatch, caplog):
             init_auth()
 
         # Verify log message
-        assert "Authentication system DISABLED - all routes are public" in caplog.text
+        assert (
+            "Authentication system DISABLED - all routes are public" in caplog.text
+        )
     finally:
         # Clean up
         if "auth" in sys.modules:

--- a/backend/tests/unit/test_auth_security.py
+++ b/backend/tests/unit/test_auth_security.py
@@ -65,7 +65,8 @@ def test_auth_secret_key_validation_with_custom_key(monkeypatch):
         # Verify the custom key is being used
         assert auth.AUTH_ENABLED is True
         assert (
-            auth.AUTH_SECRET_KEY == "my-secure-custom-key-for-production-use-12345678"
+            auth.AUTH_SECRET_KEY
+            == "my-secure-custom-key-for-production-use-12345678"
         )
         assert (
             auth.AUTH_SECRET_KEY

--- a/backend/tests/unit/test_device_stats_exclusion.py
+++ b/backend/tests/unit/test_device_stats_exclusion.py
@@ -93,7 +93,9 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         # iPhone should have 8 queries (10 total - 2 apple domains)
-        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
+        iphone_stats = next(
+            (d for d in results if d["device_name"] == "iPhone"), None
+        )
         assert iphone_stats is not None
         assert iphone_stats["total_queries"] == 8
         assert iphone_stats["blocked_queries"] == 5  # No apple domains were blocked
@@ -129,7 +131,9 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         # iPhone should have 8 queries (10 - 2 tracking domains)
-        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
+        iphone_stats = next(
+            (d for d in results if d["device_name"] == "iPhone"), None
+        )
         assert iphone_stats is not None
         assert iphone_stats["total_queries"] == 8
         # tracking.google.com (blocked) and api.tracking.net (blocked) excluded
@@ -146,7 +150,9 @@ class TestDeviceStatsWithDomainExclusion:
         assert macbook_stats["allowed_queries"] == 5
 
         # Router should have 4 queries (5 - 1 tracking.google.com)
-        router_stats = next((d for d in results if d["device_name"] == "Router"), None)
+        router_stats = next(
+            (d for d in results if d["device_name"] == "Router"), None
+        )
         assert router_stats is not None
         assert router_stats["total_queries"] == 4
         assert router_stats["blocked_queries"] == 1  # 2 - 1 tracking.google.com
@@ -173,7 +179,9 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         # iPhone should have 7 queries (10 - 3 excluded)
-        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
+        iphone_stats = next(
+            (d for d in results if d["device_name"] == "iPhone"), None
+        )
         assert iphone_stats is not None
         assert iphone_stats["total_queries"] == 7
         # amazon.com was blocked, facebook/youtube were allowed
@@ -181,7 +189,9 @@ class TestDeviceStatsWithDomainExclusion:
         assert iphone_stats["allowed_queries"] == 3  # 5 - 2 (facebook, youtube)
 
         # Router should have 4 queries (5 - 1 amazon)
-        router_stats = next((d for d in results if d["device_name"] == "Router"), None)
+        router_stats = next(
+            (d for d in results if d["device_name"] == "Router"), None
+        )
         assert router_stats is not None
         assert router_stats["total_queries"] == 4
         assert router_stats["blocked_queries"] == 2  # ads.example, tracking.google
@@ -216,7 +226,9 @@ class TestDeviceStatsWithDomainExclusion:
         assert len(results) == 2
 
         # Verify iPhone stats (8 queries after domain exclusion)
-        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
+        iphone_stats = next(
+            (d for d in results if d["device_name"] == "iPhone"), None
+        )
         assert iphone_stats["total_queries"] == 8
 
     @patch("models.session_factory")
@@ -241,7 +253,9 @@ class TestDeviceStatsWithDomainExclusion:
         assert len(results) == 3
 
         # iPhone: 10 total (5 blocked, 5 allowed)
-        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
+        iphone_stats = next(
+            (d for d in results if d["device_name"] == "iPhone"), None
+        )
         assert iphone_stats["total_queries"] == 10
         assert iphone_stats["blocked_queries"] == 5
         assert iphone_stats["allowed_queries"] == 5
@@ -257,7 +271,9 @@ class TestDeviceStatsWithDomainExclusion:
         assert macbook_stats["blocked_percentage"] == pytest.approx(37.5, rel=0.1)
 
         # Router: 5 total (2 blocked, 3 allowed)
-        router_stats = next((d for d in results if d["device_name"] == "Router"), None)
+        router_stats = next(
+            (d for d in results if d["device_name"] == "Router"), None
+        )
         assert router_stats["total_queries"] == 5
         assert router_stats["blocked_queries"] == 2
         assert router_stats["allowed_queries"] == 3
@@ -283,7 +299,9 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         assert len(results) == 3
-        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
+        iphone_stats = next(
+            (d for d in results if d["device_name"] == "iPhone"), None
+        )
         assert iphone_stats["total_queries"] == 10
 
     @patch("models.session_factory")
@@ -307,7 +325,9 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         # iPhone: 9 total (4 blocked, 5 allowed) after excluding ads.example.com
-        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
+        iphone_stats = next(
+            (d for d in results if d["device_name"] == "iPhone"), None
+        )
         assert iphone_stats["total_queries"] == 9
         assert iphone_stats["blocked_queries"] == 4  # 5 - 1 (ads)
         assert iphone_stats["allowed_queries"] == 5
@@ -341,7 +361,9 @@ class TestDeviceStatsWithDomainExclusion:
         # ads.example.com
         # Remaining: gateway.icloud.com, facebook.com, analytics.facebook.com,
         # youtube.com, google.com, amazon.com
-        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
+        iphone_stats = next(
+            (d for d in results if d["device_name"] == "iPhone"), None
+        )
         assert iphone_stats is not None
         assert iphone_stats["total_queries"] == 6
         assert (

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -131,7 +131,9 @@ class TestFetchStatusModel:
         test_db.commit()
 
         retrieved = (
-            test_db.query(FetchStatus).filter_by(profile_id="test-profile-123").first()
+            test_db.query(FetchStatus)
+            .filter_by(profile_id="test-profile-123")
+            .first()
         )
         assert retrieved is not None
         assert retrieved.profile_id == "test-profile-123"

--- a/backend/tests/unit/test_models_queries.py
+++ b/backend/tests/unit/test_models_queries.py
@@ -23,7 +23,9 @@ def test_extract_tld_with_query_context():
     """Test TLD extraction in query processing context."""
     # Test cases that might come up in actual DNS log processing
     assert extract_tld("cdn.example.com") == "example.com"
-    assert extract_tld("api.service.domain.co.uk") == "co.uk"  # Complex TLD extraction
+    assert (
+        extract_tld("api.service.domain.co.uk") == "co.uk"
+    )  # Complex TLD extraction
     assert extract_tld("subdomain.long-domain-name.org") == "long-domain-name.org"
 
 

--- a/backend/tests/unit/test_settings.py
+++ b/backend/tests/unit/test_settings.py
@@ -1,0 +1,401 @@
+# file: backend/tests/unit/test_settings.py
+"""
+🧱 Unit Tests for NextDNS Settings Models and Helper Functions
+
+Testing the settings LEGO pieces — API key storage, profile management,
+and env-var migration logic.
+"""
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+import pytest
+from models import SystemSetting, NextDNSProfile, DNSLog, FetchStatus
+
+# Mark all tests in this module as unit tests
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Model tests (use test_db SQLite fixture directly)
+# ---------------------------------------------------------------------------
+
+
+class TestSystemSettingModel:
+    """Test SystemSetting database model."""
+
+    def test_create_setting(self, test_db):
+        """Test inserting a key/value setting."""
+        setting = SystemSetting(key="nextdns_api_key", value="abc123")
+        test_db.add(setting)
+        test_db.commit()
+
+        retrieved = (
+            test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
+        )
+        assert retrieved is not None
+        assert retrieved.value == "abc123"
+        assert retrieved.created_at is not None
+        assert retrieved.updated_at is not None
+
+    def test_setting_primary_key_uniqueness(self, test_db):
+        """Test that inserting the same key twice raises an error."""
+        from sqlalchemy.exc import IntegrityError
+
+        test_db.add(SystemSetting(key="dup_key", value="first"))
+        test_db.commit()
+        test_db.add(SystemSetting(key="dup_key", value="second"))
+        with pytest.raises(IntegrityError):
+            test_db.commit()
+        test_db.rollback()
+
+    def test_setting_nullable_value(self, test_db):
+        """Test that value can be None."""
+        setting = SystemSetting(key="empty_key", value=None)
+        test_db.add(setting)
+        test_db.commit()
+
+        retrieved = test_db.query(SystemSetting).filter_by(key="empty_key").first()
+        assert retrieved.value is None
+
+
+class TestNextDNSProfileModel:
+    """Test NextDNSProfile database model."""
+
+    def test_create_profile(self, test_db):
+        """Test inserting a profile."""
+        profile = NextDNSProfile(profile_id="abc123", enabled=True)
+        test_db.add(profile)
+        test_db.commit()
+
+        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="abc123").first()
+        assert retrieved is not None
+        assert retrieved.enabled is True
+        assert retrieved.created_at is not None
+
+    def test_profile_defaults_to_enabled(self, test_db):
+        """Test that new profiles default to enabled=True."""
+        profile = NextDNSProfile(profile_id="def456")
+        test_db.add(profile)
+        test_db.commit()
+
+        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="def456").first()
+        assert retrieved.enabled is True
+
+    def test_disable_profile(self, test_db):
+        """Test disabling a profile."""
+        profile = NextDNSProfile(profile_id="ghi789", enabled=True)
+        test_db.add(profile)
+        test_db.commit()
+
+        profile.enabled = False
+        test_db.commit()
+
+        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="ghi789").first()
+        assert retrieved.enabled is False
+
+    def test_profile_primary_key_uniqueness(self, test_db):
+        """Test that the same profile_id cannot be inserted twice."""
+        from sqlalchemy.exc import IntegrityError
+
+        test_db.add(NextDNSProfile(profile_id="dup"))
+        test_db.commit()
+        test_db.add(NextDNSProfile(profile_id="dup"))
+        with pytest.raises(IntegrityError):
+            test_db.commit()
+        test_db.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests (patch session_factory to use the test SQLite session)
+# ---------------------------------------------------------------------------
+
+
+def _make_session_patcher(test_db):
+    """Return a context manager that replaces session_factory with one using test_db."""
+    mock_factory = MagicMock(return_value=test_db)
+    # Prevent the test session from being closed by the helper functions
+    test_db.close = lambda: None
+    return patch("models.session_factory", mock_factory)
+
+
+class TestGetSetSetting:
+    """Test get_setting / set_setting helpers."""
+
+    def test_get_missing_key_returns_none(self, test_db):
+        """get_setting returns None when key does not exist."""
+        from models import get_setting
+
+        with _make_session_patcher(test_db):
+            assert get_setting("nonexistent") is None
+
+    def test_set_and_get_setting(self, test_db):
+        """set_setting persists a value, get_setting retrieves it."""
+        from models import get_setting, set_setting
+
+        with _make_session_patcher(test_db):
+            assert set_setting("test_key", "hello") is True
+            assert get_setting("test_key") == "hello"
+
+    def test_set_setting_upserts(self, test_db):
+        """set_setting updates an existing key."""
+        from models import get_setting, set_setting
+
+        with _make_session_patcher(test_db):
+            set_setting("update_key", "first")
+            set_setting("update_key", "second")
+            assert get_setting("update_key") == "second"
+
+
+class TestApiKeyHelpers:
+    """Test get_nextdns_api_key / set_nextdns_api_key helpers."""
+
+    def test_returns_none_when_no_key_no_env(self, test_db, monkeypatch):
+        """Returns None when DB is empty and env var is unset."""
+        from models import get_nextdns_api_key
+
+        monkeypatch.delenv("API_KEY", raising=False)
+        with _make_session_patcher(test_db):
+            assert get_nextdns_api_key() is None
+
+    def test_falls_back_to_env_var(self, test_db, monkeypatch):
+        """Falls back to API_KEY env var when DB has no entry."""
+        from models import get_nextdns_api_key
+
+        monkeypatch.setenv("API_KEY", "env-key-123")
+        with _make_session_patcher(test_db):
+            assert get_nextdns_api_key() == "env-key-123"
+
+    def test_db_key_takes_priority_over_env(self, test_db, monkeypatch):
+        """DB value overrides env var when both are set."""
+        from models import get_nextdns_api_key, set_nextdns_api_key
+
+        monkeypatch.setenv("API_KEY", "env-key")
+        with _make_session_patcher(test_db):
+            set_nextdns_api_key("db-key")
+            assert get_nextdns_api_key() == "db-key"
+
+    def test_set_nextdns_api_key_persists(self, test_db):
+        """set_nextdns_api_key stores the key in system_settings."""
+        from models import set_nextdns_api_key
+
+        with _make_session_patcher(test_db):
+            assert set_nextdns_api_key("my-secret-key") is True
+            row = test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
+            assert row is not None
+            assert row.value == "my-secret-key"
+
+
+class TestProfileHelpers:
+    """Test profile management helper functions."""
+
+    def test_add_and_get_profile(self, test_db):
+        """add_profile inserts, get_profile retrieves."""
+        from models import add_profile, get_profile
+
+        with _make_session_patcher(test_db):
+            assert add_profile("abc123") is True
+            row = get_profile("abc123")
+            assert row is not None
+            assert row.profile_id == "abc123"
+            assert row.enabled is True
+
+    def test_add_duplicate_profile_returns_false(self, test_db):
+        """Adding the same profile twice returns False."""
+        from models import add_profile
+
+        with _make_session_patcher(test_db):
+            assert add_profile("abc123") is True
+            assert add_profile("abc123") is False
+
+    def test_get_active_profile_ids_returns_only_enabled(self, test_db):
+        """get_active_profile_ids excludes disabled profiles."""
+        from models import add_profile, update_profile_enabled, get_active_profile_ids
+
+        with _make_session_patcher(test_db):
+            add_profile("p1")
+            add_profile("p2")
+            add_profile("p3")
+            update_profile_enabled("p2", False)
+            active = get_active_profile_ids()
+            assert "p1" in active
+            assert "p3" in active
+            assert "p2" not in active
+
+    def test_get_active_profile_ids_falls_back_to_env(self, test_db, monkeypatch):
+        """Falls back to PROFILE_IDS env var when DB table is empty."""
+        from models import get_active_profile_ids
+
+        monkeypatch.setenv("PROFILE_IDS", "env1,env2")
+        with _make_session_patcher(test_db):
+            ids = get_active_profile_ids()
+            assert ids == ["env1", "env2"]
+
+    def test_update_profile_enabled(self, test_db):
+        """update_profile_enabled toggles enabled status."""
+        from models import add_profile, update_profile_enabled, get_profile
+
+        with _make_session_patcher(test_db):
+            add_profile("p1")
+            assert update_profile_enabled("p1", False) is True
+            assert get_profile("p1").enabled is False
+            assert update_profile_enabled("p1", True) is True
+            assert get_profile("p1").enabled is True
+
+    def test_update_nonexistent_profile_returns_false(self, test_db):
+        """update_profile_enabled returns False for unknown profile_id."""
+        from models import update_profile_enabled
+
+        with _make_session_patcher(test_db):
+            assert update_profile_enabled("nope", True) is False
+
+    def test_get_all_profiles_returns_all(self, test_db):
+        """get_all_profiles returns both enabled and disabled profiles."""
+        from models import add_profile, update_profile_enabled, get_all_profiles
+
+        with _make_session_patcher(test_db):
+            add_profile("p1")
+            add_profile("p2")
+            update_profile_enabled("p2", False)
+            rows = get_all_profiles()
+            ids = [r.profile_id for r in rows]
+            assert "p1" in ids
+            assert "p2" in ids
+
+
+class TestDeleteProfileData:
+    """Test data cleanup on profile deletion."""
+
+    def test_delete_profile_data_removes_logs_and_status(self, test_db):
+        """delete_profile_data removes DNS logs and fetch status for a profile."""
+        from models import delete_profile_data
+        from datetime import datetime, timezone
+
+        # Insert DNS logs for two profiles
+        for i in range(5):
+            test_db.add(
+                DNSLog(
+                    timestamp=datetime.now(timezone.utc),
+                    domain=f"test{i}.com",
+                    profile_id="victim",
+                    client_ip=f"1.1.1.{i}",
+                    data="{}",
+                )
+            )
+        for i in range(3):
+            test_db.add(
+                DNSLog(
+                    timestamp=datetime.now(timezone.utc),
+                    domain=f"keep{i}.com",
+                    profile_id="keeper",
+                    client_ip=f"2.2.2.{i}",
+                    data="{}",
+                )
+            )
+        test_db.add(
+            FetchStatus(
+                profile_id="victim",
+                last_fetch_timestamp=datetime.now(timezone.utc),
+                records_fetched=5,
+            )
+        )
+        test_db.commit()
+
+        with _make_session_patcher(test_db):
+            result = delete_profile_data("victim")
+
+        assert result["dns_logs_deleted"] == 5
+        assert result["fetch_status_deleted"] == 1
+        # Keeper logs must be untouched
+        remaining = test_db.query(DNSLog).filter_by(profile_id="keeper").count()
+        assert remaining == 3
+
+    def test_delete_profile_removes_profile_row(self, test_db):
+        """delete_profile removes the NextDNSProfile row and its data."""
+        from models import add_profile, delete_profile
+
+        with _make_session_patcher(test_db):
+            add_profile("victim")
+            result = delete_profile("victim", delete_data=False)
+            assert result["deleted"] is True
+            row = test_db.query(NextDNSProfile).filter_by(profile_id="victim").first()
+            assert row is None
+
+    def test_delete_nonexistent_profile_returns_deleted_false(self, test_db):
+        """delete_profile returns deleted=False for unknown profile."""
+        from models import delete_profile
+
+        with _make_session_patcher(test_db):
+            result = delete_profile("ghost")
+            assert result["deleted"] is False
+
+
+class TestMigrateConfigFromEnv:
+    """Test one-time startup migration from env vars."""
+
+    def test_seeds_api_key_and_profiles_when_empty(self, test_db, monkeypatch):
+        """migrate_config_from_env seeds DB from env vars on first boot."""
+        from models import migrate_config_from_env, get_setting, get_active_profile_ids
+
+        monkeypatch.setenv("API_KEY", "migrate-key")
+        monkeypatch.setenv("PROFILE_IDS", "p1,p2")
+
+        with _make_session_patcher(test_db):
+            seeded = migrate_config_from_env()
+            assert seeded is True
+            assert get_setting("nextdns_api_key") == "migrate-key"
+            ids = get_active_profile_ids()
+            assert "p1" in ids
+            assert "p2" in ids
+
+    def test_skips_migration_when_tables_populated(self, test_db, monkeypatch):
+        """migrate_config_from_env is a no-op when tables already have data."""
+        from models import migrate_config_from_env, set_nextdns_api_key, add_profile
+
+        monkeypatch.setenv("API_KEY", "new-key")
+        monkeypatch.setenv("PROFILE_IDS", "new-profile")
+
+        with _make_session_patcher(test_db):
+            set_nextdns_api_key("existing-key")
+            add_profile("existing-profile")
+            seeded = migrate_config_from_env()
+            assert seeded is False
+            # Original values must not be overwritten
+            row = test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
+            assert row.value == "existing-key"
+
+    def test_migration_without_env_vars(self, test_db, monkeypatch):
+        """migrate_config_from_env handles missing env vars gracefully."""
+        from models import migrate_config_from_env
+
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.delenv("PROFILE_IDS", raising=False)
+
+        with _make_session_patcher(test_db):
+            seeded = migrate_config_from_env()
+            # Returns False because nothing was actually seeded
+            assert seeded is False
+
+
+class TestMaskApiKey:
+    """Test the API key masking utility in main.py."""
+
+    def test_mask_long_key(self):
+        """Last 4 chars are visible, rest are bullets."""
+        from main import _mask_api_key
+
+        assert _mask_api_key("abcdef1234") == "••••••1234"
+
+    def test_mask_short_key(self):
+        """Keys of 4 chars or less are fully masked."""
+        from main import _mask_api_key
+
+        assert _mask_api_key("ab") == "••••"
+        assert _mask_api_key("abcd") == "••••"
+
+    def test_mask_exact_five_chars(self):
+        """5-char key shows last 4."""
+        from main import _mask_api_key
+
+        assert _mask_api_key("abcde") == "•bcde"

--- a/backend/tests/unit/test_settings.py
+++ b/backend/tests/unit/test_settings.py
@@ -69,7 +69,9 @@ class TestNextDNSProfileModel:
         test_db.add(profile)
         test_db.commit()
 
-        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="abc123").first()
+        retrieved = (
+            test_db.query(NextDNSProfile).filter_by(profile_id="abc123").first()
+        )
         assert retrieved is not None
         assert retrieved.enabled is True
         assert retrieved.created_at is not None
@@ -80,7 +82,9 @@ class TestNextDNSProfileModel:
         test_db.add(profile)
         test_db.commit()
 
-        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="def456").first()
+        retrieved = (
+            test_db.query(NextDNSProfile).filter_by(profile_id="def456").first()
+        )
         assert retrieved.enabled is True
 
     def test_disable_profile(self, test_db):
@@ -92,7 +96,9 @@ class TestNextDNSProfileModel:
         profile.enabled = False
         test_db.commit()
 
-        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="ghi789").first()
+        retrieved = (
+            test_db.query(NextDNSProfile).filter_by(profile_id="ghi789").first()
+        )
         assert retrieved.enabled is False
 
     def test_profile_primary_key_uniqueness(self, test_db):
@@ -182,7 +188,9 @@ class TestApiKeyHelpers:
 
         with _make_session_patcher(test_db):
             assert set_nextdns_api_key("my-secret-key") is True
-            row = test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
+            row = (
+                test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
+            )
             assert row is not None
             assert row.value == "my-secret-key"
 
@@ -211,7 +219,11 @@ class TestProfileHelpers:
 
     def test_get_active_profile_ids_returns_only_enabled(self, test_db):
         """get_active_profile_ids excludes disabled profiles."""
-        from models import add_profile, update_profile_enabled, get_active_profile_ids
+        from models import (
+            add_profile,
+            update_profile_enabled,
+            get_active_profile_ids,
+        )
 
         with _make_session_patcher(test_db):
             add_profile("p1")
@@ -319,7 +331,9 @@ class TestDeleteProfileData:
             add_profile("victim")
             result = delete_profile("victim", delete_data=False)
             assert result["deleted"] is True
-            row = test_db.query(NextDNSProfile).filter_by(profile_id="victim").first()
+            row = (
+                test_db.query(NextDNSProfile).filter_by(profile_id="victim").first()
+            )
             assert row is None
 
     def test_delete_nonexistent_profile_returns_deleted_false(self, test_db):
@@ -336,7 +350,11 @@ class TestMigrateConfigFromEnv:
 
     def test_seeds_api_key_and_profiles_when_empty(self, test_db, monkeypatch):
         """migrate_config_from_env seeds DB from env vars on first boot."""
-        from models import migrate_config_from_env, get_setting, get_active_profile_ids
+        from models import (
+            migrate_config_from_env,
+            get_setting,
+            get_active_profile_ids,
+        )
 
         monkeypatch.setenv("API_KEY", "migrate-key")
         monkeypatch.setenv("PROFILE_IDS", "p1,p2")
@@ -362,7 +380,9 @@ class TestMigrateConfigFromEnv:
             seeded = migrate_config_from_env()
             assert seeded is False
             # Original values must not be overwritten
-            row = test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
+            row = (
+                test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
+            )
             assert row.value == "existing-key"
 
     def test_migration_without_env_vars(self, test_db, monkeypatch):

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -83,9 +83,11 @@ def main():
 
         if not api_key_configured or not active_profiles:
             logger.warning(
-                "⚠️  Worker started but NextDNS API credentials " "not fully configured"
+                "⚠️  Worker started but NextDNS API credentials"
+                " not fully configured"
             )
-            logger.warning("⚠️  Scheduler will not fetch logs until credentials are set")
+            logger.warning("⚠️  Scheduler will not fetch logs until"
+                           " credentials are set")
             logger.warning(
                 "💡 Use PUT /settings/nextdns/api-key"
                 " and POST /settings/nextdns/profiles"

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -83,11 +83,12 @@ def main():
 
         if not api_key_configured or not active_profiles:
             logger.warning(
-                "⚠️  Worker started but NextDNS API credentials not fully configured"
+                "⚠️  Worker started but NextDNS API credentials " "not fully configured"
             )
             logger.warning("⚠️  Scheduler will not fetch logs until credentials are set")
             logger.warning(
-                "💡 Use PUT /settings/nextdns/api-key and POST /settings/nextdns/profiles"
+                "💡 Use PUT /settings/nextdns/api-key"
+                " and POST /settings/nextdns/profiles"
             )
 
     except ImportError as e:

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -86,8 +86,9 @@ def main():
                 "⚠️  Worker started but NextDNS API credentials"
                 " not fully configured"
             )
-            logger.warning("⚠️  Scheduler will not fetch logs until"
-                           " credentials are set")
+            logger.warning(
+                "⚠️  Scheduler will not fetch logs until" " credentials are set"
+            )
             logger.warning(
                 "💡 Use PUT /settings/nextdns/api-key"
                 " and POST /settings/nextdns/profiles"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     ports:
       - "5001:5000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   frontend:
     build:
@@ -33,3 +34,9 @@ services:
       - ./db:/docker-entrypoint-initdb.d
     ports:
       - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s


### PR DESCRIPTION
Closes #117

## Summary

- **New `system_settings` table** — generic key/value store (shared foundation with #115). First key: `nextdns_api_key`
- **New `nextdns_profiles` table** — replaces `PROFILE_IDS` env var with a managed DB list
- **Alembic migration** to create both tables
- **6 new API endpoints** under `/settings/nextdns/`
- **Scheduler now polls DB** on every fetch cycle — credential changes take effect without a restart
- **One-time startup migration** seeds the DB from `API_KEY` / `PROFILE_IDS` env vars on first boot, then becomes a no-op

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/settings/nextdns/api-key` | Returns masked key + configured flag |
| `PUT` | `/settings/nextdns/api-key` | Validates against NextDNS API, then persists |
| `GET` | `/settings/nextdns/profiles` | Lists all profiles (enabled + disabled) |
| `POST` | `/settings/nextdns/profiles` | Adds profile (validates it exists on NextDNS) |
| `PUT` | `/settings/nextdns/profiles/{id}` | Enable / disable a profile |
| `DELETE` | `/settings/nextdns/profiles/{id}` | Delete profile + purge DNS logs / fetch status |

## What changed

- `scheduler.py` — removed module-level env-var globals; `fetch_logs()` re-reads API key and active profiles from DB on every invocation
- `profile_service.py` — reads API key from DB; `get_configured_profile_ids()` reads from DB
- `worker.py` — calls `migrate_config_from_env()` on startup
- `main.py` — same migration call in lifespan + new endpoints

## Test plan

- [ ] 50 new tests (31 unit, 19 integration) — all green
- [ ] Full suite: 161 passed, 4 skipped (known bcrypt/Python 3.14), 0 failures
- [ ] pylint: 9.82/10 (up from 9.81)
- [ ] Black: all clean
- [ ] Verify first-boot migration seeds DB from env vars
- [ ] Verify `PUT /settings/nextdns/api-key` rejects invalid keys
- [ ] Verify `DELETE /settings/nextdns/profiles/{id}` purges DNS logs

Related: #115 (general system settings), #116 (frontend settings UI)