### PR TITLE
perf: two-level stats cache (TTL + pre-computed DB table) for 4M+ record performance

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -92,9 +92,7 @@ def get_password_hash(password: str) -> str:
 
 
 # JWT token functions
-def create_access_token(
-    data: dict, expires_delta: Optional[timedelta] = None
-) -> str:
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     """Create a JWT access token."""
     to_encode = data.copy()
     if expires_delta:

--- a/backend/main.py
+++ b/backend/main.py
@@ -202,9 +202,7 @@ def verify_api_key(credentials: HTTPAuthorizationCredentials = Depends(security)
 # Flexible authentication supporting both Bearer and X-API-Key
 def verify_api_key_flexible(
     x_api_key: str = Header(None),
-    credentials: HTTPAuthorizationCredentials = Depends(
-        HTTPBearer(auto_error=False)
-    ),
+    credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
 ):
     """Authenticate user with API key via Bearer token or X-API-Key header."""
     api_key = None
@@ -604,9 +602,7 @@ async def detailed_health_check():
         total_records = get_total_record_count()
 
         # Calculate uptime
-        uptime_seconds = (
-            datetime.now(timezone.utc) - app_start_time
-        ).total_seconds()
+        uptime_seconds = (datetime.now(timezone.utc) - app_start_time).total_seconds()
 
         # Get environment configuration
         fetch_interval = int(os.getenv("FETCH_INTERVAL", "60"))
@@ -614,9 +610,7 @@ async def detailed_health_check():
 
         # Create metrics components
         backend_resources = _create_backend_resources(uptime_seconds)
-        backend_health = BackendHealth(
-            status="healthy", uptime_seconds=uptime_seconds
-        )
+        backend_health = BackendHealth(status="healthy", uptime_seconds=uptime_seconds)
         backend_metrics = BackendMetrics(
             resources=backend_resources, health=backend_health
         )
@@ -882,9 +876,7 @@ async def get_profile_information(current_user: str = Depends(get_current_user))
     profile_info = get_multiple_profiles_info(configured_profiles)
     logger.info(f"🧱 Returning information for {len(profile_info)} profiles")
 
-    return ProfileInfoResponse(
-        profiles=profile_info, total_profiles=len(profile_info)
-    )
+    return ProfileInfoResponse(profiles=profile_info, total_profiles=len(profile_info))
 
 
 @app.get(
@@ -909,9 +901,7 @@ async def get_single_profile_info(
     return NextDNSProfileInfo(**profile_info)
 
 
-@app.get(
-    "/stats/overview", response_model=StatsOverviewResponse, tags=["Statistics"]
-)
+@app.get("/stats/overview", response_model=StatsOverviewResponse, tags=["Statistics"])
 async def get_stats_overview(
     profile: Optional[str] = Query(
         default=None, description="Filter by specific profile ID"
@@ -1133,15 +1123,9 @@ async def get_top_tlds(
         cache_key = make_cache_key("tlds", profile, time_range, limit=limit)
         cached = get_cached(cache_key)
         if cached is not None:
-            blocked_tlds = [
-                TopDomainsItem(**item) for item in cached["blocked_tlds"]
-            ]
-            allowed_tlds = [
-                TopDomainsItem(**item) for item in cached["allowed_tlds"]
-            ]
-            return TopTLDsResponse(
-                blocked_tlds=blocked_tlds, allowed_tlds=allowed_tlds
-            )
+            blocked_tlds = [TopDomainsItem(**item) for item in cached["blocked_tlds"]]
+            allowed_tlds = [TopDomainsItem(**item) for item in cached["allowed_tlds"]]
+            return TopTLDsResponse(blocked_tlds=blocked_tlds, allowed_tlds=allowed_tlds)
 
     # Cache miss or filtered/custom-limit request — compute live
     tlds_data = get_stats_tlds(
@@ -1513,9 +1497,7 @@ class SystemSettingsUpdateRequest(BaseModel):
     log_level: Optional[str] = None
 
 
-@app.get(
-    "/settings/system", response_model=SystemSettingsResponse, tags=["Settings"]
-)
+@app.get("/settings/system", response_model=SystemSettingsResponse, tags=["Settings"])
 async def get_system_settings(
     current_user: str = Depends(get_current_user),
 ):
@@ -1527,9 +1509,7 @@ async def get_system_settings(
     )
 
 
-@app.put(
-    "/settings/system", response_model=SystemSettingsResponse, tags=["Settings"]
-)
+@app.put("/settings/system", response_model=SystemSettingsResponse, tags=["Settings"])
 async def update_system_settings(
     body: SystemSettingsUpdateRequest,
     current_user: str = Depends(get_current_user),

--- a/backend/models.py
+++ b/backend/models.py
@@ -165,14 +165,10 @@ class ForceText(TypeDecorator):  # pylint: disable=too-many-ancestors
             return str(value)
         return value
 
-    def process_result_value(
-        self, value, dialect
-    ):  # pylint: disable=unused-argument
+    def process_result_value(self, value, dialect):  # pylint: disable=unused-argument
         return value
 
-    def process_literal_param(
-        self, value, dialect
-    ):  # pylint: disable=unused-argument
+    def process_literal_param(self, value, dialect):  # pylint: disable=unused-argument
         """Process literal parameter for SQL compilation."""
         return str(value) if value is not None else value
 
@@ -223,9 +219,7 @@ class DNSLog(Base):
     tld = Column(
         String(255), nullable=True
     )  # Computed TLD for fast aggregation (Phase 3)
-    data = Column(
-        ForceText, nullable=False
-    )  # Store original raw data as JSON string
+    data = Column(ForceText, nullable=False)  # Store original raw data as JSON string
     created_at = Column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
@@ -1057,9 +1051,7 @@ def get_stats_timeseries(
         elif time_range == "7d":
             # For daily data, align to start of today and work backwards
             today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-            start_time = today_start - timedelta(
-                days=6
-            )  # 6 days back + today = 7 days
+            start_time = today_start - timedelta(days=6)  # 6 days back + today = 7 days
             interval_hours = 24
             num_intervals = 7  # 7 x 1day = 7 days
             granularity = "day"
@@ -1245,9 +1237,7 @@ def get_stats_timeseries(
         # Return format depends on grouping mode
         if group_by == "profile":
             # Get list of all available profiles from the query
-            all_profiles = (
-                base_query.with_entities(DNSLog.profile_id).distinct().all()
-            )
+            all_profiles = base_query.with_entities(DNSLog.profile_id).distinct().all()
             available_profiles = [p[0] for p in all_profiles if p[0]]
 
             return {
@@ -1653,14 +1643,10 @@ def get_stats_devices(  # pylint: disable=too-many-locals,too-many-branches
         device_results = []
         for device_name, stats in device_stats.items():
             blocked_percentage = (
-                (stats["blocked"] / stats["total"] * 100)
-                if stats["total"] > 0
-                else 0
+                (stats["blocked"] / stats["total"] * 100) if stats["total"] > 0 else 0
             )
             allowed_percentage = (
-                (stats["allowed"] / stats["total"] * 100)
-                if stats["total"] > 0
-                else 0
+                (stats["allowed"] / stats["total"] * 100) if stats["total"] > 0 else 0
             )
 
             device_results.append(
@@ -1723,9 +1709,7 @@ def get_database_metrics():  # pylint: disable=too-many-branches,too-many-statem
                 text("SELECT count(*) as total_connections FROM pg_stat_activity")
             ).fetchone()
 
-            max_connections = session.execute(
-                text("SHOW max_connections")
-            ).fetchone()
+            max_connections = session.execute(text("SHOW max_connections")).fetchone()
 
             if connection_stats and total_connections and max_connections:
                 active = connection_stats[0]
@@ -2050,9 +2034,7 @@ def get_all_profiles() -> list:
     """Return all NextDNSProfile rows (enabled and disabled)."""
     session = session_factory()
     try:
-        return (
-            session.query(NextDNSProfile).order_by(NextDNSProfile.profile_id).all()
-        )
+        return session.query(NextDNSProfile).order_by(NextDNSProfile.profile_id).all()
     except SQLAlchemyError as e:
         logger.error(f"❌ Error reading profiles: {e}")
         return []

--- a/backend/profile_service.py
+++ b/backend/profile_service.py
@@ -8,9 +8,7 @@ from models import get_nextdns_api_key, get_active_profile_ids
 logger = get_logger(__name__)
 
 
-def _create_error_profile_info(
-    profile_id: str, name_suffix: str, error: str
-) -> Dict:
+def _create_error_profile_info(profile_id: str, name_suffix: str, error: str) -> Dict:
     """Helper function to create error profile information."""
     return {
         "id": profile_id,
@@ -23,9 +21,7 @@ def _handle_api_response(response: requests.Response, profile_id: str) -> Dict:
     """Helper function to handle API response based on status code."""
     if response.status_code == 200:
         profile_data = response.json().get("data", {})
-        logger.debug(
-            f"✅ Profile {profile_id}: {profile_data.get('name', 'Unknown')}"
-        )
+        logger.debug(f"✅ Profile {profile_id}: {profile_data.get('name', 'Unknown')}")
         return {
             "id": profile_id,
             "name": profile_data.get("name", f"Profile {profile_id}"),

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -96,9 +96,7 @@ def fetch_logs():  # pylint: disable=too-many-locals,too-many-branches,too-many-
                 logger.info(f"🔄 Profile {profile_id}: fetched {len(logs)} DNS logs")
 
                 if not logs:
-                    logger.info(
-                        f"✅ Profile {profile_id}: no new records to process"
-                    )
+                    logger.info(f"✅ Profile {profile_id}: no new records to process")
                     successful_profiles += 1
                     continue
 
@@ -202,6 +200,4 @@ logger.info(
     f"🕰️ Fetch interval configured: {FETCH_INTERVAL} minutes ({FETCH_INTERVAL/60:.1f} hours)"
 )
 logger.info("📊 Fetch limit is read from DB on each fetch cycle")
-logger.info(
-    "🧱 API key, profiles and fetch limit are read from DB on each fetch cycle"
-)
+logger.info("🧱 API key, profiles and fetch limit are read from DB on each fetch cycle")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -38,9 +38,7 @@ def test_db():
     Base.metadata.create_all(engine)
 
     # Create session factory
-    TestingSessionLocal = sessionmaker(
-        autocommit=False, autoflush=False, bind=engine
-    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = TestingSessionLocal()
 
     try:

--- a/backend/tests/integration/test_api_logs.py
+++ b/backend/tests/integration/test_api_logs.py
@@ -147,9 +147,7 @@ def test_get_logs_with_exclude_domains(test_client, populated_test_db, monkeypat
 
     client = TestClient(app)
 
-    response = client.get(
-        "/logs?exclude=test0.example.com&exclude=test1.example.com"
-    )
+    response = client.get("/logs?exclude=test0.example.com&exclude=test1.example.com")
 
     assert response.status_code == status.HTTP_200_OK
     data = response.json()

--- a/backend/tests/integration/test_api_settings.py
+++ b/backend/tests/integration/test_api_settings.py
@@ -102,9 +102,7 @@ class TestApiKeyEndpoints:
         response = test_client.get("/settings/nextdns/api-key")
         assert response.status_code in [200, 401, 403]
 
-        response = test_client.put(
-            "/settings/nextdns/api-key", json={"api_key": "x"}
-        )
+        response = test_client.put("/settings/nextdns/api-key", json={"api_key": "x"})
         assert response.status_code in [200, 400, 401, 403, 422, 500]
 
 

--- a/backend/tests/integration/test_api_stats.py
+++ b/backend/tests/integration/test_api_stats.py
@@ -56,9 +56,7 @@ def test_get_stats_overview_with_time_range(
 
 
 @pytest.mark.integration
-def test_get_stats_overview_with_profile(
-    test_client, populated_test_db, monkeypatch
-):
+def test_get_stats_overview_with_profile(test_client, populated_test_db, monkeypatch):
     """Test GET /stats/overview with profile filter."""
     monkeypatch.setenv("AUTH_ENABLED", "false")
 

--- a/backend/tests/unit/test_auth_functions.py
+++ b/backend/tests/unit/test_auth_functions.py
@@ -117,9 +117,7 @@ async def test_get_current_user_token_without_username(monkeypatch):
 
         # Create token without 'sub' field
         token = create_access_token({"role": "admin"})  # Missing 'sub'
-        credentials = HTTPAuthorizationCredentials(
-            scheme="Bearer", credentials=token
-        )
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
         # Should raise 401 when username (sub) is missing
         with pytest.raises(HTTPException) as exc_info:
@@ -231,9 +229,7 @@ async def test_get_current_user_optional_token_without_username(monkeypatch):
 
         # Create token without 'sub' field
         token = create_access_token({"role": "admin"})
-        credentials = HTTPAuthorizationCredentials(
-            scheme="Bearer", credentials=token
-        )
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
         # Should return None when username is missing
         result = await get_current_user_optional(credentials=credentials)
@@ -262,9 +258,7 @@ async def test_get_current_user_optional_valid_token(monkeypatch):
 
         # Create valid token
         token = create_access_token({"sub": "testuser"})
-        credentials = HTTPAuthorizationCredentials(
-            scheme="Bearer", credentials=token
-        )
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
         # Should return username
         result = await get_current_user_optional(credentials=credentials)
@@ -325,9 +319,7 @@ def test_init_auth_when_disabled(monkeypatch, caplog):
             init_auth()
 
         # Verify log message
-        assert (
-            "Authentication system DISABLED - all routes are public" in caplog.text
-        )
+        assert "Authentication system DISABLED - all routes are public" in caplog.text
     finally:
         # Clean up
         if "auth" in sys.modules:

--- a/backend/tests/unit/test_auth_security.py
+++ b/backend/tests/unit/test_auth_security.py
@@ -65,8 +65,7 @@ def test_auth_secret_key_validation_with_custom_key(monkeypatch):
         # Verify the custom key is being used
         assert auth.AUTH_ENABLED is True
         assert (
-            auth.AUTH_SECRET_KEY
-            == "my-secure-custom-key-for-production-use-12345678"
+            auth.AUTH_SECRET_KEY == "my-secure-custom-key-for-production-use-12345678"
         )
         assert (
             auth.AUTH_SECRET_KEY

--- a/backend/tests/unit/test_device_stats_exclusion.py
+++ b/backend/tests/unit/test_device_stats_exclusion.py
@@ -93,9 +93,7 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         # iPhone should have 8 queries (10 total - 2 apple domains)
-        iphone_stats = next(
-            (d for d in results if d["device_name"] == "iPhone"), None
-        )
+        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
         assert iphone_stats is not None
         assert iphone_stats["total_queries"] == 8
         assert iphone_stats["blocked_queries"] == 5  # No apple domains were blocked
@@ -131,9 +129,7 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         # iPhone should have 8 queries (10 - 2 tracking domains)
-        iphone_stats = next(
-            (d for d in results if d["device_name"] == "iPhone"), None
-        )
+        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
         assert iphone_stats is not None
         assert iphone_stats["total_queries"] == 8
         # tracking.google.com (blocked) and api.tracking.net (blocked) excluded
@@ -150,9 +146,7 @@ class TestDeviceStatsWithDomainExclusion:
         assert macbook_stats["allowed_queries"] == 5
 
         # Router should have 4 queries (5 - 1 tracking.google.com)
-        router_stats = next(
-            (d for d in results if d["device_name"] == "Router"), None
-        )
+        router_stats = next((d for d in results if d["device_name"] == "Router"), None)
         assert router_stats is not None
         assert router_stats["total_queries"] == 4
         assert router_stats["blocked_queries"] == 1  # 2 - 1 tracking.google.com
@@ -179,9 +173,7 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         # iPhone should have 7 queries (10 - 3 excluded)
-        iphone_stats = next(
-            (d for d in results if d["device_name"] == "iPhone"), None
-        )
+        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
         assert iphone_stats is not None
         assert iphone_stats["total_queries"] == 7
         # amazon.com was blocked, facebook/youtube were allowed
@@ -189,9 +181,7 @@ class TestDeviceStatsWithDomainExclusion:
         assert iphone_stats["allowed_queries"] == 3  # 5 - 2 (facebook, youtube)
 
         # Router should have 4 queries (5 - 1 amazon)
-        router_stats = next(
-            (d for d in results if d["device_name"] == "Router"), None
-        )
+        router_stats = next((d for d in results if d["device_name"] == "Router"), None)
         assert router_stats is not None
         assert router_stats["total_queries"] == 4
         assert router_stats["blocked_queries"] == 2  # ads.example, tracking.google
@@ -226,9 +216,7 @@ class TestDeviceStatsWithDomainExclusion:
         assert len(results) == 2
 
         # Verify iPhone stats (8 queries after domain exclusion)
-        iphone_stats = next(
-            (d for d in results if d["device_name"] == "iPhone"), None
-        )
+        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
         assert iphone_stats["total_queries"] == 8
 
     @patch("models.session_factory")
@@ -253,9 +241,7 @@ class TestDeviceStatsWithDomainExclusion:
         assert len(results) == 3
 
         # iPhone: 10 total (5 blocked, 5 allowed)
-        iphone_stats = next(
-            (d for d in results if d["device_name"] == "iPhone"), None
-        )
+        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
         assert iphone_stats["total_queries"] == 10
         assert iphone_stats["blocked_queries"] == 5
         assert iphone_stats["allowed_queries"] == 5
@@ -271,9 +257,7 @@ class TestDeviceStatsWithDomainExclusion:
         assert macbook_stats["blocked_percentage"] == pytest.approx(37.5, rel=0.1)
 
         # Router: 5 total (2 blocked, 3 allowed)
-        router_stats = next(
-            (d for d in results if d["device_name"] == "Router"), None
-        )
+        router_stats = next((d for d in results if d["device_name"] == "Router"), None)
         assert router_stats["total_queries"] == 5
         assert router_stats["blocked_queries"] == 2
         assert router_stats["allowed_queries"] == 3
@@ -299,9 +283,7 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         assert len(results) == 3
-        iphone_stats = next(
-            (d for d in results if d["device_name"] == "iPhone"), None
-        )
+        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
         assert iphone_stats["total_queries"] == 10
 
     @patch("models.session_factory")
@@ -325,9 +307,7 @@ class TestDeviceStatsWithDomainExclusion:
         )
 
         # iPhone: 9 total (4 blocked, 5 allowed) after excluding ads.example.com
-        iphone_stats = next(
-            (d for d in results if d["device_name"] == "iPhone"), None
-        )
+        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
         assert iphone_stats["total_queries"] == 9
         assert iphone_stats["blocked_queries"] == 4  # 5 - 1 (ads)
         assert iphone_stats["allowed_queries"] == 5
@@ -361,9 +341,7 @@ class TestDeviceStatsWithDomainExclusion:
         # ads.example.com
         # Remaining: gateway.icloud.com, facebook.com, analytics.facebook.com,
         # youtube.com, google.com, amazon.com
-        iphone_stats = next(
-            (d for d in results if d["device_name"] == "iPhone"), None
-        )
+        iphone_stats = next((d for d in results if d["device_name"] == "iPhone"), None)
         assert iphone_stats is not None
         assert iphone_stats["total_queries"] == 6
         assert (

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -131,9 +131,7 @@ class TestFetchStatusModel:
         test_db.commit()
 
         retrieved = (
-            test_db.query(FetchStatus)
-            .filter_by(profile_id="test-profile-123")
-            .first()
+            test_db.query(FetchStatus).filter_by(profile_id="test-profile-123").first()
         )
         assert retrieved is not None
         assert retrieved.profile_id == "test-profile-123"

--- a/backend/tests/unit/test_models_queries.py
+++ b/backend/tests/unit/test_models_queries.py
@@ -19,9 +19,7 @@ def test_extract_tld_with_query_context():
     """Test TLD extraction in query processing context."""
     # Test cases that might come up in actual DNS log processing
     assert extract_tld("cdn.example.com") == "example.com"
-    assert (
-        extract_tld("api.service.domain.co.uk") == "co.uk"
-    )  # Complex TLD extraction
+    assert extract_tld("api.service.domain.co.uk") == "co.uk"  # Complex TLD extraction
     assert extract_tld("subdomain.long-domain-name.org") == "long-domain-name.org"
 
 

--- a/backend/tests/unit/test_settings.py
+++ b/backend/tests/unit/test_settings.py
@@ -67,9 +67,7 @@ class TestNextDNSProfileModel:
         test_db.add(profile)
         test_db.commit()
 
-        retrieved = (
-            test_db.query(NextDNSProfile).filter_by(profile_id="abc123").first()
-        )
+        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="abc123").first()
         assert retrieved is not None
         assert retrieved.enabled is True
         assert retrieved.created_at is not None
@@ -80,9 +78,7 @@ class TestNextDNSProfileModel:
         test_db.add(profile)
         test_db.commit()
 
-        retrieved = (
-            test_db.query(NextDNSProfile).filter_by(profile_id="def456").first()
-        )
+        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="def456").first()
         assert retrieved.enabled is True
 
     def test_disable_profile(self, test_db):
@@ -94,9 +90,7 @@ class TestNextDNSProfileModel:
         profile.enabled = False
         test_db.commit()
 
-        retrieved = (
-            test_db.query(NextDNSProfile).filter_by(profile_id="ghi789").first()
-        )
+        retrieved = test_db.query(NextDNSProfile).filter_by(profile_id="ghi789").first()
         assert retrieved.enabled is False
 
     def test_profile_primary_key_uniqueness(self, test_db):
@@ -186,9 +180,7 @@ class TestApiKeyHelpers:
 
         with _make_session_patcher(test_db):
             assert set_nextdns_api_key("my-secret-key") is True
-            row = (
-                test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
-            )
+            row = test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
             assert row is not None
             assert row.value == "my-secret-key"
 
@@ -329,9 +321,7 @@ class TestDeleteProfileData:
             add_profile("victim")
             result = delete_profile("victim", delete_data=False)
             assert result["deleted"] is True
-            row = (
-                test_db.query(NextDNSProfile).filter_by(profile_id="victim").first()
-            )
+            row = test_db.query(NextDNSProfile).filter_by(profile_id="victim").first()
             assert row is None
 
     def test_delete_nonexistent_profile_returns_deleted_false(self, test_db):
@@ -378,9 +368,7 @@ class TestMigrateConfigFromEnv:
             seeded = migrate_config_from_env()
             assert seeded is False
             # Original values must not be overwritten
-            row = (
-                test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
-            )
+            row = test_db.query(SystemSetting).filter_by(key="nextdns_api_key").first()
             assert row.value == "existing-key"
 
     def test_migration_without_env_vars(self, test_db, monkeypatch):

--- a/backend/tests/unit/test_stats_cache.py
+++ b/backend/tests/unit/test_stats_cache.py
@@ -198,9 +198,7 @@ class TestGetCached:
     def test_l2_hit_deserializes_payload(self):
         """DB cache hit returns deserialized Python object."""
         payload = {"total_queries": 100, "blocked_queries": 10}
-        with patch(
-            "stats_cache.get_db_stats_cache", return_value=json.dumps(payload)
-        ):
+        with patch("stats_cache.get_db_stats_cache", return_value=json.dumps(payload)):
             result = get_cached("db:key")
 
         assert result == payload
@@ -208,9 +206,7 @@ class TestGetCached:
     def test_l2_hit_warms_l1_cache(self):
         """DB hit populates in-memory cache so next call skips the DB."""
         payload = {"val": 99}
-        with patch(
-            "stats_cache.get_db_stats_cache", return_value=json.dumps(payload)
-        ):
+        with patch("stats_cache.get_db_stats_cache", return_value=json.dumps(payload)):
             get_cached("warm:key")
 
         assert "warm:key" in stats_cache._MEMORY_CACHE
@@ -218,9 +214,7 @@ class TestGetCached:
     def test_l2_hit_subsequent_call_is_l1(self):
         """After L2 warms L1, the second request does not hit the DB."""
         payload = {"val": 1}
-        with patch(
-            "stats_cache.get_db_stats_cache", return_value=json.dumps(payload)
-        ):
+        with patch("stats_cache.get_db_stats_cache", return_value=json.dumps(payload)):
             get_cached("warm2:key")
 
         with patch("stats_cache.get_db_stats_cache") as mock_db:
@@ -231,9 +225,7 @@ class TestGetCached:
 
     def test_l2_invalid_json_returns_none(self):
         """Corrupted JSON in the DB cache returns None without raising."""
-        with patch(
-            "stats_cache.get_db_stats_cache", return_value="not-valid-json{{"
-        ):
+        with patch("stats_cache.get_db_stats_cache", return_value="not-valid-json{{"):
             result = get_cached("bad:key")
 
         assert result is None
@@ -262,9 +254,7 @@ class TestGetCached:
     def test_l2_hit_with_list_payload(self):
         """List values (e.g. timeseries) are correctly round-tripped."""
         payload = [{"timestamp": "2026-01-01", "total_queries": 5}]
-        with patch(
-            "stats_cache.get_db_stats_cache", return_value=json.dumps(payload)
-        ):
+        with patch("stats_cache.get_db_stats_cache", return_value=json.dumps(payload)):
             result = get_cached("list:key")
 
         assert result == payload
@@ -325,9 +315,7 @@ class TestStoreCached:
 
     def test_serialization_error_does_not_raise(self):
         """If json.dumps raises, store_cached logs the error but does not propagate."""
-        with patch(
-            "stats_cache.json.dumps", side_effect=TypeError("cannot serialize")
-        ):
+        with patch("stats_cache.json.dumps", side_effect=TypeError("cannot serialize")):
             with patch("stats_cache.upsert_db_stats_cache") as mock_upsert:
                 store_cached("err:key", {"ok": True})  # must not raise
 
@@ -345,9 +333,7 @@ class TestStoreCached:
     def test_nested_structure_stored_correctly(self):
         """Complex nested dicts/lists are JSON round-tripped without loss."""
         value = {
-            "blocked_domains": [
-                {"domain": "evil.com", "count": 10, "percentage": 5.0}
-            ],
+            "blocked_domains": [{"domain": "evil.com", "count": 10, "percentage": 5.0}],
             "allowed_domains": [],
         }
         with patch("stats_cache.upsert_db_stats_cache") as mock_upsert:
@@ -520,9 +506,7 @@ class TestPrecomputeAllStats:
         # 4 profiles (None + p1 + p2 + p3) × 5 ranges
         assert m_ov.call_count == 4 * len(PRECOMPUTE_RANGES)
 
-    def test_overview_error_does_not_abort_other_stat_types(
-        self, mock_stat_functions
-    ):
+    def test_overview_error_does_not_abort_other_stat_types(self, mock_stat_functions):
         """A failing overview computation is isolated; other types still run."""
         mock_stat_functions["overview"].side_effect = Exception("DB timeout")
 
@@ -532,9 +516,7 @@ class TestPrecomputeAllStats:
         assert mock_stat_functions["timeseries"].call_count == 2 * len(
             PRECOMPUTE_RANGES
         )
-        assert mock_stat_functions["domains"].call_count == 2 * len(
-            PRECOMPUTE_RANGES
-        )
+        assert mock_stat_functions["domains"].call_count == 2 * len(PRECOMPUTE_RANGES)
 
     def test_timeseries_error_does_not_abort_other_stat_types(
         self, mock_stat_functions
@@ -544,12 +526,8 @@ class TestPrecomputeAllStats:
 
         precompute_all_stats()
 
-        assert mock_stat_functions["overview"].call_count == 2 * len(
-            PRECOMPUTE_RANGES
-        )
-        assert mock_stat_functions["domains"].call_count == 2 * len(
-            PRECOMPUTE_RANGES
-        )
+        assert mock_stat_functions["overview"].call_count == 2 * len(PRECOMPUTE_RANGES)
+        assert mock_stat_functions["domains"].call_count == 2 * len(PRECOMPUTE_RANGES)
 
     def test_domains_error_does_not_abort_tlds_or_devices(self, mock_stat_functions):
         """Domains failure is isolated; tlds and devices still run."""
@@ -558,9 +536,7 @@ class TestPrecomputeAllStats:
         precompute_all_stats()
 
         assert mock_stat_functions["tlds"].call_count == 2 * len(PRECOMPUTE_RANGES)
-        assert mock_stat_functions["devices"].call_count == 2 * len(
-            PRECOMPUTE_RANGES
-        )
+        assert mock_stat_functions["devices"].call_count == 2 * len(PRECOMPUTE_RANGES)
 
     def test_all_stats_fail_does_not_raise(self, mock_stat_functions):
         """Total failure across all stat types must not propagate to the caller."""

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -78,15 +78,12 @@ def main():
         active_profiles = get_active_profile_ids()
 
         logger.info(f"⏰ Fetch interval: {fetch_interval} minutes")
-        logger.info(
-            "🔑 API Key configured: %s", "Yes" if api_key_configured else "No"
-        )
+        logger.info("🔑 API Key configured: %s", "Yes" if api_key_configured else "No")
         logger.info(f"📊 Monitoring {len(active_profiles)} active profile(s)")
 
         if not api_key_configured or not active_profiles:
             logger.warning(
-                "⚠️  Worker started but NextDNS API credentials"
-                " not fully configured"
+                "⚠️  Worker started but NextDNS API credentials" " not fully configured"
             )
             logger.warning(
                 "⚠️  Scheduler will not fetch logs until" " credentials are set"


### PR DESCRIPTION
## Summary

Closes #183 — dashboard stats were slow because every API request ran live aggregation queries against the full `dns_logs` table (48 separate queries for timeseries alone).

- **Level 1**: `cachetools.TTLCache(maxsize=512, ttl=300)` — in-memory, 5-min TTL, zero DB round-trips on hit
- **Level 2**: `stats_cache` DB table (Alembic migration `b2c3d4e5f6a1`) — persistent, survives restarts, shared across K8s multi-pod deployments
- **Fallback**: live query when both levels miss (first boot, or requests with custom `exclude` domain filters)

### How it works

The scheduler calls `precompute_all_stats()` after every fetch cycle, pre-computing all 5 stat types × all active profiles × `[1h, 6h, 24h, 7d, 30d]` time ranges. Results land in both caches.

On the request path, each endpoint checks the cache first (only for unfiltered default-limit requests). On a cache miss it runs the live query and warms both cache levels so subsequent requests are served instantly.

```
Request → L1 (TTLCache, 5-min) → L2 (stats_cache DB table) → Live query
```

### Files changed

| File | Change |
|------|--------|
| `backend/requirements.txt` | Add `cachetools>=5.3.0` |
| `backend/alembic/versions/2026_02_25_b2c3d4e5f6a1_add_stats_cache_table.py` | New migration — `stats_cache` table |
| `backend/models.py` | `StatsCache` model + `get_db_stats_cache` / `upsert_db_stats_cache` |
| `backend/stats_cache.py` | New module — cache engine + `precompute_all_stats()` |
| `backend/scheduler.py` | Call `precompute_all_stats()` after each fetch cycle |
| `backend/main.py` | Cache check/store on all 5 stats endpoints |

### What is and isn't cached

**Cached** (default requests, no domain exclusion filters):
- `GET /stats/overview`
- `GET /stats/timeseries` (status grouping only)
- `GET /stats/domains` (limit=10)
- `GET /stats/tlds` (limit=10)
- `GET /stats/devices` (limit=10)

**Always live** (custom filters bypass cache):
- Any request with `exclude=...` domain filters
- Timeseries with `group_by=profile`
- Any `limit` != 10 on domains/tlds/devices

## Test plan

- [x] All 161 backend tests pass (`pytest tests/ -v`)
- [x] `black` and `pylint` pass (10.00/10 on `stats_cache.py`)
- [x] Alembic migration applied cleanly against local DB
- [x] Live smoke test confirms `⚡ Cache L1 hit` on second call (backend logs)
- [x] Filtered requests still return fresh data (cache bypassed)