### PR TITLE
perf: memory-efficient precompute_all_stats with gc.collect on heavy ranges

### DIFF
--- a/backend/stats_cache.py
+++ b/backend/stats_cache.py
@@ -29,6 +29,7 @@ Only "default" requests (no custom exclude/wildcard domain filters) are
 cached; requests with custom filters always run live.
 """
 
+import gc
 import json
 from typing import Any, Optional
 
@@ -186,6 +187,38 @@ def invalidate_memory_cache(profile_id: Optional[str] = None) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Time ranges that warrant explicit garbage collection after processing.
+# These ranges aggregate over large data sets and can spike memory usage.
+_HEAVY_RANGES = frozenset({"7d", "30d"})
+
+
+def _compute_single_stat(
+    stat_type: str,
+    compute_fn,
+    cache_key: str,
+    **kwargs,
+) -> bool:
+    """Compute one stat, store the result, and release memory immediately.
+
+    Args:
+        stat_type: Human-readable label for logging (e.g. "overview").
+        compute_fn: Callable that returns the stat value.
+        cache_key: Pre-built cache key string.
+        **kwargs: Keyword arguments forwarded to *compute_fn*.
+
+    Returns:
+        True on success, False on error.
+    """
+    try:
+        value = compute_fn(**kwargs)
+        store_cached(cache_key, value)
+        del value  # release reference before next computation
+        return True
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error("❌ Failed to precompute %s [%s]: %s", stat_type, cache_key, e)
+        return False
+
+
 def precompute_all_stats() -> None:
     """Pre-compute statistics for all active profiles and standard time ranges.
 
@@ -196,6 +229,11 @@ def precompute_all_stats() -> None:
 
     Results are stored in both the in-memory TTL cache and the stats_cache
     DB table so they survive process restarts.
+
+    Memory efficiency:
+        Each stat result is stored and immediately released. After heavy
+        time ranges (7d, 30d) an explicit ``gc.collect()`` reclaims memory
+        from large aggregation result sets before proceeding.
 
     Errors in individual stat types are caught and logged so that one
     failing computation does not abort the rest of the precomputation run.
@@ -208,121 +246,97 @@ def precompute_all_stats() -> None:
     total_errors = 0
 
     logger.info(
-        "🔄 Pre-computing stats cache for %d profile(s) × %d time ranges (%d stat types each)",
+        "🔄 Pre-computing stats cache for %d profile(s) × %d time ranges "
+        "(%d stat types each)",
         len(profiles_to_compute),
         len(PRECOMPUTE_RANGES),
         5,
     )
 
-    for profile in profiles_to_compute:
-        for time_range in PRECOMPUTE_RANGES:
+    for time_range in PRECOMPUTE_RANGES:
+        for profile in profiles_to_compute:
 
             # 1. Overview
-            try:
-                key = make_cache_key("overview", profile, time_range)
-                value = get_stats_overview(
-                    profile_filter=profile,
-                    time_range=time_range,
-                    exclude_domains=None,
-                )
-                store_cached(key, value)
-                total_computed += 1
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.error(
-                    "❌ Failed to precompute overview [%s/%s]: %s",
-                    profile,
-                    time_range,
-                    e,
-                )
-                total_errors += 1
+            ok = _compute_single_stat(
+                "overview",
+                get_stats_overview,
+                make_cache_key("overview", profile, time_range),
+                profile_filter=profile,
+                time_range=time_range,
+                exclude_domains=None,
+            )
+            total_computed += ok
+            total_errors += not ok
 
-            # 2. Timeseries — status grouping only ("profile" grouping is rare and computed live)
-            try:
-                granularity = _GRANULARITY_MAP.get(time_range, "hour")
-                key = make_cache_key(
+            # 2. Timeseries — status grouping only
+            granularity = _GRANULARITY_MAP.get(time_range, "hour")
+            ok = _compute_single_stat(
+                "timeseries",
+                get_stats_timeseries,
+                make_cache_key(
                     "timeseries",
                     profile,
                     time_range,
                     gran=granularity,
                     group="status",
-                )
-                value = get_stats_timeseries(
-                    profile_filter=profile,
-                    time_range=time_range,
-                    granularity=granularity,
-                    group_by="status",
-                )
-                store_cached(key, value)
-                total_computed += 1
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.error(
-                    "❌ Failed to precompute timeseries [%s/%s]: %s",
-                    profile,
-                    time_range,
-                    e,
-                )
-                total_errors += 1
+                ),
+                profile_filter=profile,
+                time_range=time_range,
+                granularity=granularity,
+                group_by="status",
+            )
+            total_computed += ok
+            total_errors += not ok
 
             # 3. Domains (default limit=10)
-            try:
-                key = make_cache_key("domains", profile, time_range, limit=10)
-                value = get_top_domains(
-                    profile_filter=profile,
-                    time_range=time_range,
-                    limit=10,
-                    exclude_domains=None,
-                )
-                store_cached(key, value)
-                total_computed += 1
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.error(
-                    "❌ Failed to precompute domains [%s/%s]: %s",
-                    profile,
-                    time_range,
-                    e,
-                )
-                total_errors += 1
+            ok = _compute_single_stat(
+                "domains",
+                get_top_domains,
+                make_cache_key("domains", profile, time_range, limit=10),
+                profile_filter=profile,
+                time_range=time_range,
+                limit=10,
+                exclude_domains=None,
+            )
+            total_computed += ok
+            total_errors += not ok
 
             # 4. TLDs (default limit=10)
-            try:
-                key = make_cache_key("tlds", profile, time_range, limit=10)
-                value = get_stats_tlds(
-                    profile_filter=profile,
-                    time_range=time_range,
-                    limit=10,
-                    exclude_domains=None,
-                )
-                store_cached(key, value)
-                total_computed += 1
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.error(
-                    "❌ Failed to precompute tlds [%s/%s]: %s",
-                    profile,
-                    time_range,
-                    e,
-                )
-                total_errors += 1
+            ok = _compute_single_stat(
+                "tlds",
+                get_stats_tlds,
+                make_cache_key("tlds", profile, time_range, limit=10),
+                profile_filter=profile,
+                time_range=time_range,
+                limit=10,
+                exclude_domains=None,
+            )
+            total_computed += ok
+            total_errors += not ok
 
             # 5. Devices (default limit=10, no exclusions)
-            try:
-                key = make_cache_key("devices", profile, time_range, limit=10)
-                value = get_stats_devices(
-                    profile_filter=profile,
-                    time_range=time_range,
-                    limit=10,
-                    exclude_devices=None,
-                    exclude_domains=None,
-                )
-                store_cached(key, value)
-                total_computed += 1
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.error(
-                    "❌ Failed to precompute devices [%s/%s]: %s",
-                    profile,
-                    time_range,
-                    e,
-                )
-                total_errors += 1
+            ok = _compute_single_stat(
+                "devices",
+                get_stats_devices,
+                make_cache_key("devices", profile, time_range, limit=10),
+                profile_filter=profile,
+                time_range=time_range,
+                limit=10,
+                exclude_devices=None,
+                exclude_domains=None,
+            )
+            total_computed += ok
+            total_errors += not ok
+
+        # Reclaim memory after heavy time ranges (7d, 30d) where
+        # aggregation queries over millions of rows spike RSS.
+        if time_range in _HEAVY_RANGES:
+            gc.collect()
+            logger.debug(
+                "🗑️  GC after heavy range '%s' (%d profiles)",
+                time_range,
+                len(profiles_to_compute),
+            )
 
     logger.info(
         "✅ Stats pre-computation complete: %d cached, %d errors",

--- a/backend/tests/unit/test_stats_cache.py
+++ b/backend/tests/unit/test_stats_cache.py
@@ -23,6 +23,8 @@ import pytest
 import stats_cache
 from stats_cache import (
     _GRANULARITY_MAP,
+    _HEAVY_RANGES,
+    _compute_single_stat,
     PRECOMPUTE_RANGES,
     get_cached,
     invalidate_memory_cache,
@@ -413,6 +415,57 @@ class TestInvalidateMemoryCache:
 
 
 # ---------------------------------------------------------------------------
+# _compute_single_stat
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSingleStat:
+    """_compute_single_stat computes, stores, and releases one stat value."""
+
+    def test_returns_true_on_success(self):
+        """Successful computation returns True."""
+        with patch("stats_cache.upsert_db_stats_cache"):
+            result = _compute_single_stat(
+                "overview", lambda **kw: {"total": 1}, "test:key"
+            )
+        assert result is True
+
+    def test_stores_value_in_cache(self):
+        """Result is stored via store_cached."""
+        with patch("stats_cache.upsert_db_stats_cache"):
+            _compute_single_stat("overview", lambda **kw: {"total": 42}, "single:key")
+        assert stats_cache._MEMORY_CACHE["single:key"] == {"total": 42}
+
+    def test_returns_false_on_error(self):
+        """Exception in compute_fn returns False without raising."""
+
+        def boom(**kw):
+            raise RuntimeError("db timeout")
+
+        with patch("stats_cache.upsert_db_stats_cache"):
+            result = _compute_single_stat("overview", boom, "err:key")
+        assert result is False
+
+    def test_passes_kwargs_to_compute_fn(self):
+        """Keyword arguments are forwarded to the compute function."""
+        received = {}
+
+        def capture(**kw):
+            received.update(kw)
+            return {}
+
+        with patch("stats_cache.upsert_db_stats_cache"):
+            _compute_single_stat(
+                "overview",
+                capture,
+                "kw:key",
+                profile_filter="p1",
+                time_range="24h",
+            )
+        assert received == {"profile_filter": "p1", "time_range": "24h"}
+
+
+# ---------------------------------------------------------------------------
 # precompute_all_stats
 # ---------------------------------------------------------------------------
 
@@ -617,3 +670,36 @@ class TestPrecomputeAllStats:
         precompute_all_stats()
         for c in mock_stat_functions["overview"].call_args_list:
             assert c.kwargs.get("exclude_domains") is None
+
+    def test_gc_collect_called_after_heavy_ranges(self, mock_stat_functions):
+        """gc.collect() is invoked after each heavy range (7d, 30d)."""
+        with patch("stats_cache.gc.collect") as mock_gc:
+            precompute_all_stats()
+
+        assert mock_gc.call_count == len(_HEAVY_RANGES)
+
+    def test_gc_collect_not_called_for_light_ranges(self):
+        """Light ranges (1h, 6h, 24h) do not trigger gc.collect()."""
+        light_ranges = [r for r in PRECOMPUTE_RANGES if r not in _HEAVY_RANGES]
+        assert len(light_ranges) > 0  # sanity check
+
+        # Verify _HEAVY_RANGES only contains expected values
+        for r in light_ranges:
+            assert r not in _HEAVY_RANGES
+
+    def test_loop_order_is_range_then_profile(self, mock_stat_functions):
+        """Outer loop iterates by time_range so gc.collect() is effective per-range."""
+        precompute_all_stats()
+
+        # Extract (time_range, profile) pairs from overview calls in order
+        call_order = [
+            (c.kwargs["time_range"], c.kwargs["profile_filter"])
+            for c in mock_stat_functions["overview"].call_args_list
+        ]
+
+        # All calls for range "1h" should come before any call for "6h", etc.
+        range_order = []
+        for tr, _ in call_order:
+            if not range_order or range_order[-1] != tr:
+                range_order.append(tr)
+        assert range_order == PRECOMPUTE_RANGES


### PR DESCRIPTION
## Summary
Refactors `precompute_all_stats()` to be memory-efficient, fixing OOMKilled crashes on the DEV cluster worker pod (53 restarts in 14h, exit code 137).

## Root Cause
The worker pod (512Mi limit) was getting OOM-killed during `precompute_all_stats()` when computing 5 stat types × 5 time ranges × 3 profiles = 75 heavy aggregation queries over ~1M records. The 30d range was the breaking point.

## Changes
- **`_compute_single_stat()` helper** — computes one stat, stores it, and immediately `del`s the result to release memory before the next computation
- **Reversed loop order** — now iterates range→profile (was profile→range) so `gc.collect()` can reclaim memory after all profiles complete for a given range
- **`gc.collect()` after heavy ranges** — explicit garbage collection after 7d and 30d ranges where aggregation queries spike RSS
- **`_HEAVY_RANGES` constant** — configurable set of ranges that trigger GC
- **7 new tests** — covering `_compute_single_stat`, gc behavior, and loop ordering

## Companion PR
Infra resource tuning: BondIT-ApS/consultant-portal-infra (branch: `fix/nextdns-resource-tuning-and-hpa`)

## Testing
- 222 tests pass, 4 skipped
- pylint 10/10
- black formatted