### PR TITLE
fix: upgrade PyJWT to 2.12.0 to fix crit header CVE (Dependabot #41)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,7 +21,7 @@ psutil==7.2.2
 
 # Authentication and security
 passlib[bcrypt]==1.7.4
-PyJWT[crypto]==2.11.0  # Replaced python-jose to avoid ecdsa vulnerabilities (CVE-2024-64396, CVE-2024-64459)
+PyJWT[crypto]==2.12.0  # Replaced python-jose to avoid ecdsa vulnerabilities (CVE-2024-64396, CVE-2024-64459)
 slowapi==0.1.9
 
 # Security: Pin transitive dependencies to fix CVE vulnerabilities

--- a/backend/tests/seed_e2e_data.py
+++ b/backend/tests/seed_e2e_data.py
@@ -211,14 +211,12 @@ def seed(engine) -> None:
 
         # Bulk insert — fresh test DB so no conflict handling needed
         session.execute(
-            text(
-                """
+            text("""
                 INSERT INTO dns_logs
                     (timestamp, domain, tld, blocked, action, profile_id, device, data, created_at, query_type)
                 VALUES
                     (:timestamp, :domain, :tld, :blocked, :action, :profile_id, :device, :data, :created_at, :query_type)
-                """
-            ),
+                """),
             records,
         )
         session.commit()

--- a/docs/deployment-notes/2026-03-18-pyjwt-security-upgrade.md
+++ b/docs/deployment-notes/2026-03-18-pyjwt-security-upgrade.md
@@ -1,0 +1,10 @@
+# Security: Upgrade PyJWT to 2.12.0
+
+**Date:** 2026-03-18
+**Alert:** Dependabot #41 — HIGH
+
+## CVE
+PyJWT accepts unknown `crit` header extensions, allowing bypass of critical header verification.
+
+## Fix
+Upgraded `PyJWT[crypto]` from `2.11.0` → `2.12.0` (first patched version).


### PR DESCRIPTION
## Security Fix

Closes Dependabot alert #41 (HIGH)

**CVE:** PyJWT accepts unknown `crit` header extensions, allowing bypass of critical header verification.

**Fix:** `PyJWT[crypto]` upgraded from `2.11.0` → `2.12.0`