### PR TITLE
🧹 Extract reload_auth_module fixture (fixes #424)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,4 @@ frontend/tsconfig.tsbuildinfo
 
 # Safety checks
 .safety-project.ini
+.mcp.json

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -175,6 +175,22 @@ def api_key():
     return "test-api-key-123"
 
 
+@pytest.fixture
+def reload_auth_module():
+    """
+    Ensure the `auth` module is freshly imported for tests that depend on
+    environment-driven module-level state.
+
+    Removes any cached `auth` module before and after the test so each test
+    starts from a clean import and never leaks state to subsequent tests.
+    """
+    if "auth" in sys.modules:
+        del sys.modules["auth"]
+    yield
+    if "auth" in sys.modules:
+        del sys.modules["auth"]
+
+
 @pytest.fixture(autouse=True)
 def mock_env_vars(monkeypatch):
     """

--- a/backend/tests/unit/test_auth_functions.py
+++ b/backend/tests/unit/test_auth_functions.py
@@ -5,7 +5,6 @@ Additional unit tests for auth.py functions to improve coverage.
 Tests authentication dependency functions and initialization.
 """
 
-import sys
 import pytest
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
@@ -13,341 +12,220 @@ from fastapi.security import HTTPAuthorizationCredentials
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_when_auth_disabled(monkeypatch):
+async def test_get_current_user_when_auth_disabled(monkeypatch, reload_auth_module):
     """Test get_current_user returns 'anonymous' when AUTH_ENABLED=false."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
-    # Mock auth disabled
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user
+    from auth import get_current_user
 
-        # Should return anonymous without credentials
-        result = await get_current_user(credentials=None)
-        assert result == "anonymous"
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    result = await get_current_user(credentials=None)
+    assert result == "anonymous"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_no_credentials_when_auth_enabled(monkeypatch):
+async def test_get_current_user_no_credentials_when_auth_enabled(
+    monkeypatch, reload_auth_module
+):
     """Test get_current_user raises 401 when no credentials provided and auth enabled."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user
+    from auth import get_current_user
 
-        # Should raise 401 when credentials missing
-        with pytest.raises(HTTPException) as exc_info:
-            await get_current_user(credentials=None)
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(credentials=None)
 
-        assert exc_info.value.status_code == 401
-        assert exc_info.value.detail == "Not authenticated"
-        assert "WWW-Authenticate" in exc_info.value.headers
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Not authenticated"
+    assert "WWW-Authenticate" in exc_info.value.headers
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_invalid_token(monkeypatch):
+async def test_get_current_user_invalid_token(monkeypatch, reload_auth_module):
     """Test get_current_user raises 401 with invalid token."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user
+    from auth import get_current_user
 
-        # Create invalid credentials
-        invalid_credentials = HTTPAuthorizationCredentials(
-            scheme="Bearer", credentials="invalid.token.here"
-        )
+    invalid_credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials="invalid.token.here"
+    )
 
-        # Should raise 401 for invalid token
-        with pytest.raises(HTTPException) as exc_info:
-            await get_current_user(credentials=invalid_credentials)
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(credentials=invalid_credentials)
 
-        assert exc_info.value.status_code == 401
-        assert exc_info.value.detail == "Invalid authentication credentials"
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid authentication credentials"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_token_without_username(monkeypatch):
+async def test_get_current_user_token_without_username(monkeypatch, reload_auth_module):
     """Test get_current_user raises 401 when token payload missing 'sub' field."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user, create_access_token
+    from auth import get_current_user, create_access_token
 
-        # Create token without 'sub' field
-        token = create_access_token({"role": "admin"})  # Missing 'sub'
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    token = create_access_token({"role": "admin"})  # Missing 'sub'
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
-        # Should raise 401 when username (sub) is missing
-        with pytest.raises(HTTPException) as exc_info:
-            await get_current_user(credentials=credentials)
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(credentials=credentials)
 
-        assert exc_info.value.status_code == 401
-        assert exc_info.value.detail == "Invalid authentication credentials"
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid authentication credentials"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_optional_when_auth_disabled(monkeypatch):
+async def test_get_current_user_optional_when_auth_disabled(
+    monkeypatch, reload_auth_module
+):
     """Test get_current_user_optional returns None when AUTH_ENABLED=false."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user_optional
+    from auth import get_current_user_optional
 
-        # Should return None when auth disabled
-        result = await get_current_user_optional(credentials=None)
-        assert result is None
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    result = await get_current_user_optional(credentials=None)
+    assert result is None
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_optional_no_credentials(monkeypatch):
+async def test_get_current_user_optional_no_credentials(
+    monkeypatch, reload_auth_module
+):
     """Test get_current_user_optional returns None when no credentials provided."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user_optional
+    from auth import get_current_user_optional
 
-        # Should return None (not raise exception) when credentials missing
-        result = await get_current_user_optional(credentials=None)
-        assert result is None
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    result = await get_current_user_optional(credentials=None)
+    assert result is None
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_optional_invalid_token(monkeypatch):
+async def test_get_current_user_optional_invalid_token(monkeypatch, reload_auth_module):
     """Test get_current_user_optional returns None with invalid token."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user_optional
+    from auth import get_current_user_optional
 
-        # Create invalid credentials
-        invalid_credentials = HTTPAuthorizationCredentials(
-            scheme="Bearer", credentials="invalid.token.here"
-        )
+    invalid_credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials="invalid.token.here"
+    )
 
-        # Should return None (not raise exception) for invalid token
-        result = await get_current_user_optional(credentials=invalid_credentials)
-        assert result is None
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    result = await get_current_user_optional(credentials=invalid_credentials)
+    assert result is None
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_optional_token_without_username(monkeypatch):
+async def test_get_current_user_optional_token_without_username(
+    monkeypatch, reload_auth_module
+):
     """Test get_current_user_optional returns None when token missing 'sub'."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user_optional, create_access_token
+    from auth import get_current_user_optional, create_access_token
 
-        # Create token without 'sub' field
-        token = create_access_token({"role": "admin"})
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    token = create_access_token({"role": "admin"})
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
-        # Should return None when username is missing
-        result = await get_current_user_optional(credentials=credentials)
-        assert result is None
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    result = await get_current_user_optional(credentials=credentials)
+    assert result is None
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_current_user_optional_valid_token(monkeypatch):
+async def test_get_current_user_optional_valid_token(monkeypatch, reload_auth_module):
     """Test get_current_user_optional returns username with valid token."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import get_current_user_optional, create_access_token
+    from auth import get_current_user_optional, create_access_token
 
-        # Create valid token
-        token = create_access_token({"sub": "testuser"})
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    token = create_access_token({"sub": "testuser"})
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
-        # Should return username
-        result = await get_current_user_optional(credentials=credentials)
-        assert result == "testuser"
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    result = await get_current_user_optional(credentials=credentials)
+    assert result == "testuser"
 
 
 @pytest.mark.unit
-def test_init_auth_when_enabled(monkeypatch, caplog):
+def test_init_auth_when_enabled(monkeypatch, caplog, reload_auth_module):
     """Test init_auth logs correct messages when authentication is enabled."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv("AUTH_USERNAME", "admin")
     monkeypatch.setenv("AUTH_PASSWORD", "secure_password")
     monkeypatch.setenv("AUTH_SECRET_KEY", "custom-secret-key-not-default-12345678")
     monkeypatch.setenv("AUTH_SESSION_TIMEOUT", "60")
 
-    try:
-        from auth import init_auth
+    from auth import init_auth
 
-        # Call init_auth
-        with caplog.at_level("INFO"):
-            init_auth()
+    with caplog.at_level("INFO"):
+        init_auth()
 
-        # Verify log messages
-        assert "Authentication system ENABLED" in caplog.text
-        assert "Session timeout: 60 minutes" in caplog.text
-        assert "Configured username: admin" in caplog.text
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert "Authentication system ENABLED" in caplog.text
+    assert "Session timeout: 60 minutes" in caplog.text
+    assert "Configured username: admin" in caplog.text
 
 
 @pytest.mark.unit
-def test_init_auth_when_disabled(monkeypatch, caplog):
+def test_init_auth_when_disabled(monkeypatch, caplog, reload_auth_module):
     """Test init_auth logs correct message when authentication is disabled."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "test-secret-key-for-testing-only-min-32-chars"
     )
 
-    try:
-        from auth import init_auth
+    from auth import init_auth
 
-        # Call init_auth
-        with caplog.at_level("INFO"):
-            init_auth()
+    with caplog.at_level("INFO"):
+        init_auth()
 
-        # Verify log message
-        assert "Authentication system DISABLED - all routes are public" in caplog.text
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert "Authentication system DISABLED - all routes are public" in caplog.text
 
 
 @pytest.mark.unit
-def test_init_auth_warning_no_password(monkeypatch, caplog):
+def test_init_auth_warning_no_password(monkeypatch, caplog, reload_auth_module):
     """Test init_auth logs warning when AUTH_PASSWORD is not set."""
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv("AUTH_PASSWORD", "")  # Empty password
     monkeypatch.setenv("AUTH_SECRET_KEY", "custom-secret-key-not-default-12345678")
 
-    try:
-        from auth import init_auth
+    from auth import init_auth
 
-        # Call init_auth
-        with caplog.at_level("WARNING"):
-            init_auth()
+    with caplog.at_level("WARNING"):
+        init_auth()
 
-        # Verify warning message
-        assert "AUTH_PASSWORD not set" in caplog.text
-        assert "Authentication will not work properly" in caplog.text
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert "AUTH_PASSWORD not set" in caplog.text
+    assert "Authentication will not work properly" in caplog.text

--- a/backend/tests/unit/test_auth_security.py
+++ b/backend/tests/unit/test_auth_security.py
@@ -5,13 +5,11 @@ Unit tests for authentication security features added in PR #260.
 Tests the security validation that prevents using default test keys in production.
 """
 
-import sys
-
 import pytest
 
 
 @pytest.mark.unit
-def test_auth_secret_key_validation_with_default_key(monkeypatch):
+def test_auth_secret_key_validation_with_default_key(monkeypatch, reload_auth_module):
     """
     Test that importing auth module with AUTH_ENABLED=true and default
     AUTH_SECRET_KEY raises a ValueError with clear error message.
@@ -19,123 +17,75 @@ def test_auth_secret_key_validation_with_default_key(monkeypatch):
     This tests the security validation added in PR #260 that prevents
     accidentally using the test secret key in production.
     """
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
-    # Set environment to trigger validation error
     monkeypatch.setenv("AUTH_ENABLED", "true")
     # Don't set AUTH_SECRET_KEY - it will use the default test key
     monkeypatch.delenv("AUTH_SECRET_KEY", raising=False)
 
-    # Attempting to import auth should raise ValueError
     with pytest.raises(ValueError) as exc_info:
         import auth  # noqa: F401  # pylint: disable=unused-import
 
-    # Verify error message is clear and helpful
     error_message = str(exc_info.value)
     assert "AUTH_SECRET_KEY must be set to a secure value" in error_message
     assert "authentication is enabled" in error_message
 
-    # Clean up for other tests
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
 
 @pytest.mark.unit
-def test_auth_secret_key_validation_with_custom_key(monkeypatch):
+def test_auth_secret_key_validation_with_custom_key(monkeypatch, reload_auth_module):
     """
     Test that providing a custom AUTH_SECRET_KEY when AUTH_ENABLED=true
     works correctly without raising an error.
     """
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
-    # Set environment with custom secret key
     monkeypatch.setenv("AUTH_ENABLED", "true")
     monkeypatch.setenv(
         "AUTH_SECRET_KEY", "my-secure-custom-key-for-production-use-12345678"
     )
 
-    # Import should succeed without error
-    try:
-        import auth
+    import auth
 
-        # Verify the custom key is being used
-        assert auth.AUTH_ENABLED is True
-        assert (
-            auth.AUTH_SECRET_KEY == "my-secure-custom-key-for-production-use-12345678"
-        )
-        assert (
-            auth.AUTH_SECRET_KEY
-            != "test-secret-key-for-testing-only-do-not-use-in-production-min-32-chars"
-        )
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert auth.AUTH_ENABLED is True
+    assert auth.AUTH_SECRET_KEY == "my-secure-custom-key-for-production-use-12345678"
+    assert (
+        auth.AUTH_SECRET_KEY
+        != "test-secret-key-for-testing-only-do-not-use-in-production-min-32-chars"
+    )
 
 
 @pytest.mark.unit
-def test_auth_secret_key_default_when_auth_disabled(monkeypatch):
+def test_auth_secret_key_default_when_auth_disabled(monkeypatch, reload_auth_module):
     """
     Test that the default test secret key is allowed when AUTH_ENABLED=false.
 
     This ensures tests can run without explicitly setting AUTH_SECRET_KEY.
     """
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
-    # Set environment with auth disabled
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.delenv("AUTH_SECRET_KEY", raising=False)
 
-    # Import should succeed - using default test key is OK when auth is disabled
-    try:
-        import auth
+    import auth
 
-        # Verify default test key is being used
-        assert auth.AUTH_ENABLED is False
-        assert (
-            auth.AUTH_SECRET_KEY
-            == "test-secret-key-for-testing-only-do-not-use-in-production-min-32-chars"
-        )
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert auth.AUTH_ENABLED is False
+    assert (
+        auth.AUTH_SECRET_KEY
+        == "test-secret-key-for-testing-only-do-not-use-in-production-min-32-chars"
+    )
 
 
 @pytest.mark.unit
-def test_auth_config_values_from_environment(monkeypatch):
+def test_auth_config_values_from_environment(monkeypatch, reload_auth_module):
     """
     Test that authentication configuration values are correctly loaded
     from environment variables.
     """
-    # Remove auth module if already imported
-    if "auth" in sys.modules:
-        del sys.modules["auth"]
-
-    # Set custom environment values
     monkeypatch.setenv("AUTH_ENABLED", "false")
     monkeypatch.setenv("AUTH_USERNAME", "custom_admin")
     monkeypatch.setenv("AUTH_PASSWORD", "custom_password")
     monkeypatch.setenv("AUTH_SECRET_KEY", "custom-secret-key-1234567890")
     monkeypatch.setenv("AUTH_SESSION_TIMEOUT", "120")
 
-    try:
-        import auth
+    import auth
 
-        # Verify all config values are loaded correctly
-        assert auth.AUTH_ENABLED is False
-        assert auth.AUTH_USERNAME == "custom_admin"
-        assert auth.AUTH_PASSWORD == "custom_password"
-        assert auth.AUTH_SECRET_KEY == "custom-secret-key-1234567890"
-        assert auth.AUTH_SESSION_TIMEOUT == 120
-        assert auth.AUTH_ALGORITHM == "HS256"  # Should be constant
-    finally:
-        # Clean up
-        if "auth" in sys.modules:
-            del sys.modules["auth"]
+    assert auth.AUTH_ENABLED is False
+    assert auth.AUTH_USERNAME == "custom_admin"
+    assert auth.AUTH_PASSWORD == "custom_password"
+    assert auth.AUTH_SECRET_KEY == "custom-secret-key-1234567890"
+    assert auth.AUTH_SESSION_TIMEOUT == 120
+    assert auth.AUTH_ALGORITHM == "HS256"  # Should be constant


### PR DESCRIPTION
## Summary
- Adds a shared `reload_auth_module` pytest fixture in `backend/tests/conftest.py` that handles the `sys.modules['auth']` reload + cleanup pattern.
- Refactors `tests/unit/test_auth_functions.py` and `tests/unit/test_auth_security.py` to use the fixture, removing all `R0801` duplicate-code warnings flagged in #424.
- Pylint score: **9.76 → 9.77**.

Closes #424 (item 1). Item 2 (slowapi deprecation) is upstream — no action until a slowapi release fixes it or Python 3.16 lands.

## Test plan
- [x] `pytest tests/` → 222 passed, 4 skipped
- [x] `black . --check` → clean
- [x] `pylint .` → no R0801 in the touched test files