### PR TITLE
🐌 Hotfix DEV bottlenecks: indexed device filter + /profiles cache

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.exc import SQLAlchemyError
+from cachetools import TTLCache
 
 # Set up logging
 from logging_config import get_logger
@@ -620,20 +621,18 @@ def get_logs(  # pylint: disable=too-many-positional-arguments,too-many-locals,t
             has_filter = True
             logger.debug(f"🧱 Filtering for profile: '{profile_filter}'")
 
-        # Apply device filter
-        if device_filter and len(device_filter) > 0:
-            # Filter logs based on device names
-            device_conditions = []
-            for device_name in device_filter:
-                if device_name.strip():
-                    # Check for devices where the JSON device field contains the name
-                    device_conditions.append(
-                        DNSLog.device.ilike(f'%"name": "{device_name}"%')
-                    )
-            if device_conditions:
-                query = query.filter(or_(*device_conditions))
+        # Apply device filter — use the indexed ``device_name`` column
+        # added in migration c1d2e3f4a5b6. The old code did
+        # ``device.ilike('%"name": "X"%')`` which is a substring scan on
+        # JSON TEXT and triggered full-table scans (>40 s on 6M rows).
+        # ``device_name`` is the trimmed value from the JSON and is
+        # covered by ``idx_dns_logs_timestamp_device_name``.
+        if device_filter:
+            cleaned = [d.strip() for d in device_filter if d and d.strip()]
+            if cleaned:
+                query = query.filter(DNSLog.device_name.in_(cleaned))
                 has_filter = True
-                logger.debug(f"📱 Filtering for devices: {device_filter}")
+                logger.debug(f"📱 Filtering for devices: {cleaned}")
 
         # Apply time range filter
         if time_range != "all":
@@ -796,12 +795,32 @@ def get_logs_stats(profile_filter=None, time_range="all", exclude_domains=None):
 
 
 # Get list of available profiles in the database
+# ---------------------------------------------------------------------------
+# /profiles cache
+# ---------------------------------------------------------------------------
+# get_available_profiles() runs ``COUNT(*) + MAX(timestamp) GROUP BY profile_id``
+# over the full dns_logs table — ~6 M rows on DEV, ~14 M on PROD — and is hit
+# on every page load. The result barely changes minute-to-minute (a new fetch
+# only updates counts by a few hundred), so a short TTL cache is plenty.
+_PROFILES_CACHE: TTLCache = TTLCache(maxsize=1, ttl=300)  # 5-minute TTL
+_PROFILES_CACHE_KEY = "available_profiles"
+
+
 def get_available_profiles():
     """Get list of profile IDs that have data in the database.
+
+    Cached in-process for 5 minutes — the underlying full-table aggregate
+    is expensive (multi-second on multi-million-row tables) and the result
+    is not time-critical.
 
     Returns:
         list: List of profile IDs with record counts
     """
+    cached = _PROFILES_CACHE.get(_PROFILES_CACHE_KEY)
+    if cached is not None:
+        logger.debug("⚡ /profiles cache hit (%d profiles)", len(cached))
+        return cached
+
     session = session_factory()
     try:
         # Query for distinct profile IDs and their counts
@@ -834,13 +853,23 @@ def get_available_profiles():
                 }
             )
 
-        logger.debug(f"🧱 Found {len(profiles)} profiles with data")
+        _PROFILES_CACHE[_PROFILES_CACHE_KEY] = profiles
+        logger.debug(f"🧱 Found {len(profiles)} profiles with data (cached 5 min)")
         return profiles
     except SQLAlchemyError as e:
         logger.error(f"❌ Error getting available profiles: {e}")
         return []
     finally:
         session.close()
+
+
+def invalidate_profiles_cache() -> None:
+    """Clear the cached /profiles result.
+
+    Call after operations that change the profile set (e.g. profile
+    deletion) so the next request reflects the change immediately.
+    """
+    _PROFILES_CACHE.clear()
 
 
 # Get real stats overview data from database
@@ -2131,6 +2160,10 @@ def delete_profile_data(profile_id: str) -> dict:
             .delete(synchronize_session=False)
         )
         session.commit()
+        # Profile set changed — drop the cached /profiles result so the
+        # next request reflects the deletion immediately rather than
+        # showing the deleted profile for up to 5 more minutes.
+        invalidate_profiles_cache()
         logger.info(
             f"🗑️  Profile '{profile_id}' data cleaned up: "
             f"{logs_deleted} DNS logs, {fetch_deleted} fetch status rows deleted"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -153,6 +153,7 @@ def populated_test_db(test_db):
             domain=f"test{i}.example.com",
             action="allowed" if i % 2 == 0 else "blocked",
             device='{"name": "Test Device", "id": "device-123"}',
+            device_name="Test Device",
             client_ip="192.168.1.100",
             query_type="A",
             blocked=i % 2 != 0,

--- a/backend/tests/unit/test_dev_bottlenecks.py
+++ b/backend/tests/unit/test_dev_bottlenecks.py
@@ -1,0 +1,131 @@
+# file: backend/tests/unit/test_dev_bottlenecks.py
+"""Unit tests for the DEV bottleneck hotfix.
+
+Covers:
+  - B1: get_logs() device filter now uses the indexed ``device_name``
+        column instead of an unindexable ``device.ilike('%"name":...%')``.
+  - B2: get_available_profiles() now caches its result for 5 minutes.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+import models
+from models import (
+    DNSLog,
+    get_available_profiles,
+    get_logs,
+    invalidate_profiles_cache,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# B1 — device filter uses device_name column
+# ---------------------------------------------------------------------------
+
+
+def _insert(session, **overrides):
+    """Insert a minimal DNSLog row, allowing overrides."""
+    defaults = dict(
+        timestamp=datetime.now(timezone.utc),
+        domain="example.com",
+        action="allowed",
+        blocked=False,
+        profile_id="p1",
+        tld="example.com",
+        client_ip="10.0.0.1",
+        query_type="A",
+        device='{"name": "Alice iPhone", "id": "d1"}',
+        device_name="Alice iPhone",
+        data="{}",
+    )
+    defaults.update(overrides)
+    session.add(DNSLog(**defaults))
+    session.commit()
+
+
+class TestDeviceFilterUsesDeviceNameColumn:
+    """The hotfix replaces a JSON-substring scan with a column equality."""
+
+    def test_match_by_exact_device_name(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        _insert(test_db, device_name="Alice iPhone")
+        _insert(test_db, device_name="Bob iPad")
+
+        rows, total = get_logs(time_range="all", device_filter=["Alice iPhone"])
+
+        assert total == 1
+        assert rows[0]["device"]["name"] == "Alice iPhone"
+
+    def test_match_multiple_devices(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        _insert(test_db, device_name="Alice iPhone")
+        _insert(test_db, device_name="Bob iPad")
+        _insert(test_db, device_name="Charlie Mac")
+
+        _rows, total = get_logs(
+            time_range="all", device_filter=["Alice iPhone", "Bob iPad"]
+        )
+
+        assert total == 2
+
+    def test_whitespace_only_devices_are_ignored(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        _insert(test_db, device_name="Alice iPhone")
+        _insert(test_db, device_name="Bob iPad")
+
+        # Whitespace-only entries are filtered out; remaining list becomes
+        # empty, so no device filter is applied at all → returns both rows.
+        # With no filters set, get_logs falls back to the pg_class
+        # reltuples estimate (a no-op on SQLite → 0), so we just check
+        # the data rows came back uncountstrained.
+        rows, _total = get_logs(time_range="all", device_filter=["", "  "])
+
+        assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# B2 — get_available_profiles is cached
+# ---------------------------------------------------------------------------
+
+
+class TestAvailableProfilesCache:
+    """The /profiles result is cached for 5 minutes to avoid a full-table
+    aggregate on every page load."""
+
+    def setup_method(self):
+        invalidate_profiles_cache()
+
+    def teardown_method(self):
+        invalidate_profiles_cache()
+
+    def test_second_call_hits_cache(self, test_db, monkeypatch):
+        """A second call must not re-run the DB aggregate."""
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        _insert(test_db, profile_id="p1")
+
+        first = get_available_profiles()
+        # Break the DB so any real query would fail
+        monkeypatch.setattr(
+            models, "session_factory", lambda: (_ for _ in ()).throw(RuntimeError())
+        )
+
+        second = get_available_profiles()
+        assert second == first
+
+    def test_invalidate_forces_refresh(self, test_db, monkeypatch):
+        """invalidate_profiles_cache() must cause the next call to re-query."""
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        _insert(test_db, profile_id="p1")
+
+        get_available_profiles()  # prime cache
+        invalidate_profiles_cache()
+
+        # Insert a second profile after invalidation — should appear next call
+        _insert(test_db, profile_id="p2")
+        profiles = get_available_profiles()
+        ids = {p["profile_id"] for p in profiles}
+        assert ids == {"p1", "p2"}


### PR DESCRIPTION
## Summary

Caught during DEV smoke-testing of #427. Two endpoints were hitting the DB hard enough to time out browsers — both are quick fixes.

### 🔴 B1 — \`/logs\` device filter scans the full table
\`models.py\` was still doing:
\`\`\`python
DNSLog.device.ilike(f'%\"name\": \"{name}\"%')
\`\`\`
That's a substring match on the JSON \`device\` TEXT column. No index can help; it's a full-table scan.

Migration \`c1d2e3f4a5b6\` already added the \`device_name\` column + \`idx_dns_logs_timestamp_device_name\` *specifically* to fix this — the filter just never got migrated to use it. Fixed by switching to \`DNSLog.device_name.in_(cleaned)\`.

**Observed before:** GET \`/logs?profile=X&devices=Y\` took **56 408 ms** on DEV (5.8 M rows), causing the frontend to error with \"Failed to load DNS logs\".
**Expected after:** sub-200 ms (indexed equality, narrowed by the existing \`(timestamp DESC, device_name)\` composite index).

### 🟡 B2 — \`/profiles\` runs a full-table aggregate on every page nav
\`get_available_profiles()\` does \`SELECT profile_id, COUNT(*), MAX(timestamp) FROM dns_logs GROUP BY profile_id\` — scans every row. Result barely changes minute-to-minute, and the endpoint gets called on every page navigation.

Added a 5-minute in-process \`TTLCache\` (\`cachetools\`, \`maxsize=1\`). Invalidated automatically by \`delete_profile_data()\` so profile deletions appear immediately.

**Observed before:** GET \`/profiles\` took **14–42 s** on DEV.
**Expected after:** ~1 ms on cache hit, original cost only every 5 min.

## Out of scope
- **B3** (\`/profiles/info\` 42 s) — slow because the upstream NextDNS API is slow. Wants a separate look at \`profile_service.py\` caching/parallelism. Skipped at user's direction.

## Test plan
- [x] \`pytest tests/\` → **233 passed, 4 skipped** (was 228; +5 new tests covering device-filter behavior and the cache hit/invalidate paths)
- [x] \`black . --check\` → clean
- [x] \`pylint .\` → **9.77/10** (unchanged from main)
- [x] Conftest seed updated to populate \`device_name\` (no existing tests broken)

Refs #183 #427