### PR TITLE
🪟 Add log retention setting + nightly cleanup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,9 @@ from models import (
     set_fetch_limit,
     get_log_level,
     set_log_level,
+    get_retention_days,
+    set_retention_days,
+    RETENTION_MIN_DAYS,
 )
 from models import get_available_profiles as get_profiles_from_db
 from models import (
@@ -1551,6 +1554,7 @@ class SystemSettingsResponse(BaseModel):
     fetch_interval: int
     fetch_limit: int
     log_level: str
+    retention_days: int
 
 
 class SystemSettingsUpdateRequest(BaseModel):
@@ -1559,6 +1563,7 @@ class SystemSettingsUpdateRequest(BaseModel):
     fetch_interval: Optional[int] = None
     fetch_limit: Optional[int] = None
     log_level: Optional[str] = None
+    retention_days: Optional[int] = None
 
 
 @app.get("/settings/system", response_model=SystemSettingsResponse, tags=["Settings"])
@@ -1570,6 +1575,7 @@ async def get_system_settings(
         fetch_interval=get_fetch_interval(),
         fetch_limit=get_fetch_limit(),
         log_level=get_log_level(),
+        retention_days=get_retention_days(),
     )
 
 
@@ -1619,10 +1625,36 @@ async def update_system_settings(
         set_log_level(level)
         apply_log_level(level)
 
+    if body.retention_days is not None:
+        # 0 = unlimited (no cleanup). Any non-zero value must be >= 30
+        # to prevent typos like "3" or "1" from wiping data.
+        if body.retention_days != 0 and body.retention_days < RETENTION_MIN_DAYS:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"retention_days must be 0 (unlimited) or at least "
+                    f"{RETENTION_MIN_DAYS} days"
+                ),
+            )
+        if body.retention_days > 3650:  # 10 years — sanity ceiling
+            raise HTTPException(
+                status_code=422,
+                detail="retention_days must be at most 3650 (10 years)",
+            )
+        set_retention_days(body.retention_days)
+        if body.retention_days == 0:
+            logger.info("🪟 Log retention disabled (unlimited)")
+        else:
+            logger.info(
+                f"🪟 Log retention updated to {body.retention_days} days "
+                f"(cleanup runs nightly at 00:30 UTC)"
+            )
+
     return SystemSettingsResponse(
         fetch_interval=get_fetch_interval(),
         fetch_limit=get_fetch_limit(),
         log_level=get_log_level(),
+        retention_days=get_retention_days(),
     )
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1973,6 +1973,14 @@ NEXTDNS_API_KEY_SETTING = "nextdns_api_key"
 FETCH_INTERVAL_SETTING = "fetch_interval"
 FETCH_LIMIT_SETTING = "fetch_limit"
 LOG_LEVEL_SETTING = "log_level"
+RETENTION_DAYS_SETTING = "retention_days"
+
+# Retention policy constants
+RETENTION_UNLIMITED = 0  # 0 means "keep everything"
+RETENTION_MIN_DAYS = 30  # Lowest non-unlimited value allowed
+RETENTION_DELETE_BATCH_SIZE = (
+    10_000  # Rows per DELETE batch; keeps WAL/lock pressure bounded
+)
 
 
 def get_nextdns_api_key() -> Optional[str]:
@@ -2042,6 +2050,95 @@ def get_log_level() -> str:
 def set_log_level(level: str) -> bool:
     """Persist the log level to the database."""
     return set_setting(LOG_LEVEL_SETTING, level.upper())
+
+
+# ---------------------------------------------------------------------------
+# Log retention policy
+# ---------------------------------------------------------------------------
+# A ``retention_days`` setting (DB-backed, no env var) controls automatic
+# cleanup of old dns_logs rows. ``0`` means unlimited / disabled. Any other
+# value must be >= RETENTION_MIN_DAYS to avoid catastrophic data loss from a
+# typo. The nightly worker calls ``delete_logs_older_than()`` at 00:30 UTC.
+
+
+def get_retention_days() -> int:
+    """Return the configured retention in days. ``0`` means unlimited."""
+    val = get_setting(RETENTION_DAYS_SETTING)
+    if val is None:
+        return RETENTION_UNLIMITED
+    try:
+        return max(int(val), 0)
+    except ValueError:
+        return RETENTION_UNLIMITED
+
+
+def set_retention_days(days: int) -> bool:
+    """Persist the retention policy. Validation lives at the API layer."""
+    return set_setting(RETENTION_DAYS_SETTING, str(max(days, 0)))
+
+
+def delete_logs_older_than(
+    retention_days: int,
+    batch_size: int = RETENTION_DELETE_BATCH_SIZE,
+) -> int:
+    """Delete dns_logs rows older than *retention_days* in bounded batches.
+
+    Batching keeps each transaction short, which keeps WAL volume bounded
+    and avoids long locks on the (busy) table while the worker also runs
+    INSERTs. Returns the total number of rows deleted across all batches.
+
+    A retention value of ``0`` is treated as a no-op so the caller can
+    safely invoke this from a cron without checking the policy first.
+    """
+    if retention_days <= 0:
+        logger.debug("🪟 Retention disabled (retention_days=0); skipping cleanup")
+        return 0
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    logger.info(
+        "🪟 Retention cleanup starting: deleting dns_logs older than %s "
+        "(retention=%d days, batch=%d)",
+        cutoff.isoformat(),
+        retention_days,
+        batch_size,
+    )
+
+    session = session_factory()
+    total_deleted = 0
+    try:
+        while True:
+            # Subquery: pick a bounded set of old row IDs. Bounding the
+            # delete by ID set (rather than running one huge DELETE) keeps
+            # each transaction predictable in size and runtime.
+            subq = (
+                session.query(DNSLog.id)
+                .filter(DNSLog.timestamp < cutoff)
+                .limit(batch_size)
+                .subquery()
+            )
+            deleted = (
+                session.query(DNSLog)
+                .filter(DNSLog.id.in_(subq.select()))
+                .delete(synchronize_session=False)
+            )
+            session.commit()
+            if not deleted:
+                break
+            total_deleted += deleted
+            logger.debug("🪟 Retention batch deleted %d rows", deleted)
+
+        logger.info(
+            "✅ Retention cleanup complete: %d rows deleted (older than %s)",
+            total_deleted,
+            cutoff.isoformat(),
+        )
+        return total_deleted
+    except SQLAlchemyError as e:
+        session.rollback()
+        logger.error("❌ Retention cleanup failed: %s", e)
+        return total_deleted
+    finally:
+        session.close()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -206,9 +206,46 @@ def precompute_heavy_stats_job():
         logger.error("❌ Nightly heavy stats pre-computation failed: %s", e)
 
 
+def retention_cleanup_job():
+    """Nightly job: delete dns_logs older than the configured retention.
+
+    Reads the policy from the database on every run so changes via the
+    Settings UI take effect on the next nightly cycle without a restart.
+    A retention value of 0 (unlimited) is treated as a no-op.
+    """
+    try:
+        from models import (
+            get_retention_days,
+            delete_logs_older_than,
+        )  # pylint: disable=import-outside-toplevel
+
+        retention = get_retention_days()
+        if retention <= 0:
+            logger.debug("🪟 Retention cleanup skipped (unlimited / disabled)")
+            return
+        logger.info(
+            "🪟 Running nightly retention cleanup (keeping last %d days)",
+            retention,
+        )
+        delete_logs_older_than(retention)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        logger.error("❌ Nightly retention cleanup failed: %s", e)
+
+
 # Initialize and start scheduler
 scheduler = BackgroundScheduler()  # pylint: disable=invalid-name
 scheduler.add_job(fetch_logs, "interval", minutes=FETCH_INTERVAL, id="fetch_logs")
+# Nightly retention cleanup at 00:30 UTC. Runs BEFORE the heavy-stats job
+# so the 01:00 precompute reflects the post-cleanup row set immediately.
+# Reads the retention_days setting from the DB on every run, so changes
+# via the UI take effect on the next nightly cycle without a restart.
+scheduler.add_job(
+    retention_cleanup_job,
+    CronTrigger(hour=0, minute=30),
+    id="retention_cleanup",
+    replace_existing=True,
+)
+
 # Nightly job: recompute the heavy stats ranges (7d/30d) at 01:00 UTC.
 # Skipping these from every fetch cycle is the biggest single DB win for #183.
 scheduler.add_job(
@@ -221,6 +258,7 @@ scheduler.start()
 logger.info(
     f"🔄 NextDNS log fetching scheduler started (runs every {FETCH_INTERVAL} minutes)"
 )
+logger.info("🪟 Nightly retention cleanup scheduled for 00:30 UTC")
 logger.info("🌙 Nightly heavy stats pre-computation scheduled for 01:00 UTC")
 logger.info(
     f"🕰️ Fetch interval configured: {FETCH_INTERVAL} minutes ({FETCH_INTERVAL/60:.1f} hours)"

--- a/backend/tests/unit/test_log_retention.py
+++ b/backend/tests/unit/test_log_retention.py
@@ -1,0 +1,126 @@
+# file: backend/tests/unit/test_log_retention.py
+"""Unit tests for the log retention setting + nightly cleanup."""
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+import models
+from models import (
+    DNSLog,
+    RETENTION_MIN_DAYS,
+    delete_logs_older_than,
+    get_retention_days,
+    set_retention_days,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Setting getter / setter
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionSetting:
+    def test_default_is_unlimited(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        assert get_retention_days() == 0
+
+    def test_set_and_get_roundtrip(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        set_retention_days(90)
+        assert get_retention_days() == 90
+
+    def test_zero_means_unlimited(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        set_retention_days(60)
+        set_retention_days(0)
+        assert get_retention_days() == 0
+
+    def test_negative_values_clamped_to_zero(self, test_db, monkeypatch):
+        # The model layer is permissive; API layer enforces bounds.
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        set_retention_days(-5)
+        assert get_retention_days() == 0
+
+    def test_min_days_constant(self):
+        # Locked into the public API so the frontend can rely on it.
+        assert RETENTION_MIN_DAYS == 30
+
+
+# ---------------------------------------------------------------------------
+# delete_logs_older_than()
+# ---------------------------------------------------------------------------
+
+
+def _insert(session, timestamp, **overrides):
+    defaults = dict(
+        timestamp=timestamp,
+        domain="example.com",
+        action="allowed",
+        blocked=False,
+        profile_id="p1",
+        tld="example.com",
+        client_ip="10.0.0.1",
+        query_type="A",
+        device='{"name": "x"}',
+        device_name="x",
+        data="{}",
+    )
+    defaults.update(overrides)
+    session.add(DNSLog(**defaults))
+    session.commit()
+
+
+class TestDeleteLogsOlderThan:
+    def test_zero_is_noop(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        _insert(test_db, datetime.now(timezone.utc) - timedelta(days=400))
+
+        deleted = delete_logs_older_than(0)
+
+        assert deleted == 0
+        assert test_db.query(DNSLog).count() == 1
+
+    def test_negative_is_noop(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        _insert(test_db, datetime.now(timezone.utc) - timedelta(days=400))
+
+        assert delete_logs_older_than(-1) == 0
+        assert test_db.query(DNSLog).count() == 1
+
+    def test_only_old_rows_are_deleted(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        now = datetime.now(timezone.utc)
+        # 5 rows older than 30 days, 3 rows newer
+        for i in range(5):
+            _insert(test_db, now - timedelta(days=31 + i))
+        for i in range(3):
+            _insert(test_db, now - timedelta(days=i))
+
+        deleted = delete_logs_older_than(30)
+
+        assert deleted == 5
+        assert test_db.query(DNSLog).count() == 3
+
+    def test_batching_processes_all_rows(self, test_db, monkeypatch):
+        """With a tiny batch size, we should still delete every old row."""
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        now = datetime.now(timezone.utc)
+        for i in range(12):
+            _insert(test_db, now - timedelta(days=40 + i))
+
+        deleted = delete_logs_older_than(30, batch_size=4)
+
+        assert deleted == 12
+        assert test_db.query(DNSLog).count() == 0
+
+    def test_no_old_rows_no_deletes(self, test_db, monkeypatch):
+        monkeypatch.setattr(models, "session_factory", lambda: test_db)
+        _insert(test_db, datetime.now(timezone.utc))
+
+        deleted = delete_logs_older_than(30)
+
+        assert deleted == 0
+        assert test_db.query(DNSLog).count() == 1

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -66,9 +66,16 @@ interface SystemState {
   fetchInterval: string
   fetchLimit: string
   logLevel: string
+  // Retention is split into two pieces so the UI can show a checkbox
+  // ("Unlimited") that disables the days input without losing the user's
+  // previously-typed number.
+  retentionUnlimited: boolean
+  retentionDays: string
 }
 
 const LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] as const
+const RETENTION_MIN_DAYS = 30
+const RETENTION_DEFAULT_DAYS = 90 // Sensible default when unchecking "Unlimited"
 
 // ---------------------------------------------------------------------------
 // NextDNS API Key card
@@ -519,6 +526,8 @@ function SystemSettingsCard() {
     fetchInterval: '',
     fetchLimit: '',
     logLevel: 'INFO',
+    retentionUnlimited: true,
+    retentionDays: String(RETENTION_DEFAULT_DAYS),
   })
 
   const load = useCallback(async () => {
@@ -532,6 +541,13 @@ function SystemSettingsCard() {
         fetchInterval: String(data.fetch_interval),
         fetchLimit: String(data.fetch_limit),
         logLevel: data.log_level,
+        retentionUnlimited: data.retention_days === 0,
+        // Keep displaying the previous days value when "Unlimited" is on,
+        // so unchecking it doesn't reset to the global default.
+        retentionDays:
+          data.retention_days === 0
+            ? String(RETENTION_DEFAULT_DAYS)
+            : String(data.retention_days),
       }))
     } catch {
       setState(s => ({
@@ -565,12 +581,33 @@ function SystemSettingsCard() {
       return
     }
 
+    // Retention: 0 = unlimited; otherwise must be >= RETENTION_MIN_DAYS.
+    let retention = 0
+    if (!state.retentionUnlimited) {
+      retention = parseInt(state.retentionDays, 10)
+      if (isNaN(retention) || retention < RETENTION_MIN_DAYS) {
+        setState(s => ({
+          ...s,
+          error: `Retention must be at least ${RETENTION_MIN_DAYS} days, or check Unlimited`,
+        }))
+        return
+      }
+      if (retention > 3650) {
+        setState(s => ({
+          ...s,
+          error: 'Retention must be at most 3650 days (10 years)',
+        }))
+        return
+      }
+    }
+
     setState(s => ({ ...s, saving: true, error: null, success: null }))
     try {
       const updated = await apiClient.updateSystemSettings({
         fetch_interval: interval,
         fetch_limit: limit,
         log_level: state.logLevel,
+        retention_days: retention,
       })
       setState(s => ({
         ...s,
@@ -579,6 +616,11 @@ function SystemSettingsCard() {
         fetchInterval: String(updated.fetch_interval),
         fetchLimit: String(updated.fetch_limit),
         logLevel: updated.log_level,
+        retentionUnlimited: updated.retention_days === 0,
+        retentionDays:
+          updated.retention_days === 0
+            ? s.retentionDays
+            : String(updated.retention_days),
         success: 'Settings saved — changes are now active',
       }))
       setTimeout(() => setState(s => ({ ...s, success: null })), 4000)
@@ -596,11 +638,15 @@ function SystemSettingsCard() {
     }
   }
 
+  const currentRetention = state.retentionUnlimited
+    ? 0
+    : parseInt(state.retentionDays, 10) || 0
   const isDirty =
     state.settings !== null &&
     (state.fetchInterval !== String(state.settings.fetch_interval) ||
       state.fetchLimit !== String(state.settings.fetch_limit) ||
-      state.logLevel !== state.settings.log_level)
+      state.logLevel !== state.settings.log_level ||
+      currentRetention !== state.settings.retention_days)
 
   return (
     <Card>
@@ -714,6 +760,52 @@ function SystemSettingsCard() {
                   </option>
                 ))}
               </select>
+            </div>
+
+            {/* Log Retention */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium" htmlFor="retention-days">
+                Log Retention
+              </label>
+              <p className="text-xs text-muted-foreground">
+                Automatically delete DNS logs older than this many days. Runs
+                nightly at 00:30 UTC. Minimum {RETENTION_MIN_DAYS} days, or
+                check Unlimited to keep everything.
+              </p>
+              <div className="flex items-center gap-3">
+                <Input
+                  id="retention-days"
+                  type="number"
+                  min={RETENTION_MIN_DAYS}
+                  max={3650}
+                  value={state.retentionDays}
+                  disabled={state.retentionUnlimited}
+                  onChange={e =>
+                    setState(s => ({
+                      ...s,
+                      retentionDays: e.target.value,
+                      error: null,
+                    }))
+                  }
+                  className="w-32"
+                />
+                <span className="text-sm text-muted-foreground">days</span>
+                <label className="ml-4 flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={state.retentionUnlimited}
+                    onChange={e =>
+                      setState(s => ({
+                        ...s,
+                        retentionUnlimited: e.target.checked,
+                        error: null,
+                      }))
+                    }
+                    className="h-4 w-4 rounded border-input"
+                  />
+                  Unlimited
+                </label>
+              </div>
             </div>
 
             {/* Actions */}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -177,6 +177,8 @@ export interface SystemSettingsResponse {
   fetch_interval: number
   fetch_limit: number
   log_level: string
+  /** Days of dns_logs to keep. 0 = unlimited (no cleanup). */
+  retention_days: number
 }
 
 export interface VersionResponse {


### PR DESCRIPTION
## Summary
New System Setting to bound \`dns_logs\` growth: \"Keep DNS logs for N days, or check Unlimited to keep everything.\"

Per discussion: **Option A** (just delete old logs) — Option B (archive table) rejected as too much code for too little win; the real long-term answer (PostgreSQL native partitioning) is tracked as #430.

## Behavior

### Setting
- DB-backed (\`system_settings\` table, no env var)
- Default \`0\` = unlimited
- Non-zero values must be **>= 30 days** (typo guard)
- UI: number input + checkbox labeled \"Unlimited\"
  - Checked → input disabled, submits 0
  - Unchecked → input enabled, defaults to 90 days

### Cleanup
- Nightly cron at **00:30 UTC** — before the 01:00 heavy-stats precompute so it reflects post-cleanup state
- Reads setting from DB every cycle (UI changes take effect next night, no restart)
- Batched delete (10k rows per transaction) → bounded WAL volume + short lock windows
- 0 / negative retention = no-op

### API
- \`GET /settings/system\` now returns \`retention_days\`
- \`PUT /settings/system\` accepts \`retention_days: int\`
  - 422 if \`0 < value < 30\`
  - 422 if \`value > 3650\` (10y sanity ceiling)

## Out of scope (tracked in #430)
**PostgreSQL native partitioning.** That's the real win — retention becomes \`DROP PARTITION\` (O(1), no WAL storm) and partition pruning is automatic. Too big for this PR; will replace the \`DELETE\`-based cleanup once it lands.

## Test plan
- [x] \`pytest tests/\` → 243 passed (was 233, +10 new tests covering setting roundtrip, batched delete, no-op cases)
- [x] \`black\` clean
- [x] \`pylint\` → 9.76/10
- [x] Frontend \`npm run lint\` / \`type-check\` / \`format:check\` / \`test\` all clean (233 passed)
- [ ] DEV smoke: set retention, save, verify scheduler logs \"🪟 Nightly retention cleanup scheduled for 00:30 UTC\"