### PR TITLE
chore(deps): weekly maintenance bumps 2026-06-04

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@
 
 # FastAPI and ASGI server
 fastapi==0.136.3
-uvicorn[standard]==0.48.0
+uvicorn[standard]==0.49.0
 python-multipart==0.0.30
 starlette==1.2.1  # Updated to fix CVE-2025-62727 DoS vulnerabilities - compatible with FastAPI 0.135.2
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@radix-ui/react-toast": "^1.2.1",
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-query-devtools": "^5.101.0",
-        "axios": "^1.15.2",
+        "axios": "^1.17.0",
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3487,9 +3487,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-toast": "^1.2.1",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-query-devtools": "^5.101.0",
-    "axios": "^1.15.2",
+    "axios": "^1.17.0",
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Weekly dependency maintenance — 2026-06-04

Safe, non-major dependency bumps for backend (Python) and frontend (Node). Major bumps are deferred to dedicated PRs.

### 🐍 Python (backend)

| Package | From | To | File |
|---|---|---|---|
| uvicorn[standard] | 0.48.0 | 0.49.0 | backend/requirements.txt |

**Notes on skipped items from the weekly digest:**
- `pydantic_core` → 2.47.0: not a direct pin anywhere in `backend/requirements.txt` or `backend/requirements-dev.txt`. It is a transitive dependency (via `pydantic`/`fastapi`), so we leave it to be resolved transitively. No action required.
- `astroid` → 4.1.2, `safety-schemas` → 0.0.18, `typer` → 0.26.7: none of these are direct pins in `backend/requirements-dev.txt` (they come transitively via `pylint`, `safety`). Skipping per "edit pinned files only" policy — they will pick up automatically on next install.

### 📦 Node (frontend)

| Package | From | To |
|---|---|---|
| axios | prior | 1.17.0 |

### ⚠️ Deferred (major bumps)

These were **intentionally not bumped** in this PR — they are major version jumps with breaking changes that need separate evaluation/testing:

- **@eslint/js** 9 → 10 — ESLint major; flat-config / API changes, needs lint config review.
- **eslint-plugin-react-hooks** 6 → 7 — major; rule changes likely require code/config adjustments.
- **tailwindcss** 3 → 4 — major rewrite (new engine, config format changes); requires migration pass on styles + Vite/PostCSS config.

Each will get its own focused PR.

---

Closes #457
Closes #432
Closes #449
